### PR TITLE
Refactor tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '7d9a85d0ee6a', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'c6958824b77380', :submodules => true
 gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '1baa71d', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '7d9a85d0ee6a', :submodules => true
 gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '66a945940c7', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '1baa71d', :submodules => true
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,12 @@
-GIT
-  remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: 66a945940c7648599d784137077ccdd58a4b86d2
-  ref: 66a945940c7
-  submodules: true
+PATH
+  remote: /Users/emiltin/Documents/code/rsmp
   specs:
-    rsmp (0.1.12)
+    rsmp (0.1.14)
       async (~> 1.23.0)
-      async-io (~> 1.27.1)
+      async-io (~> 1.27.4)
       colorize (~> 0.8.1)
-      json_schemer (~> 0.2.8)
-      thor (~> 0.20.3)
+      json_schemer (~> 0.2.11)
+      thor (~> 1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -18,21 +15,21 @@ GEM
       console (~> 1.0)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-io (1.27.1)
+    async-io (1.27.4)
       async (~> 1.14)
     colorize (0.8.1)
-    console (1.7.0)
+    console (1.8.2)
     diff-lcs (1.3)
     ecma-re-validator (0.2.0)
       regexp_parser (~> 1.2)
     hana (1.3.5)
-    json_schemer (0.2.8)
+    json_schemer (0.2.11)
       ecma-re-validator (~> 0.2)
       hana (~> 1.3)
       regexp_parser (~> 1.5)
       uri_template (~> 0.7)
     nio4r (2.5.2)
-    regexp_parser (1.6.0)
+    regexp_parser (1.7.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -46,7 +43,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    thor (0.20.3)
+    thor (1.0.1)
     timers (4.3.0)
     uri_template (0.7.0)
 
@@ -58,4 +55,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.1.0.pre.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: 7d9a85d0ee6af867960d20b77836586d19ec2f32
-  ref: 7d9a85d0ee6a
+  revision: c6958824b77380cc3c39f267c568e2a9ef3ee8ba
+  ref: c6958824b77380
   submodules: true
   specs:
-    rsmp (0.1.15)
+    rsmp (0.1.17)
       async (~> 1.23.0)
       async-io (~> 1.27.4)
       colorize (~> 0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,10 @@
-PATH
-  remote: /Users/emiltin/Documents/code/rsmp
+GIT
+  remote: https://github.com/rsmp-nordic/rsmp.git
+  revision: 7d9a85d0ee6af867960d20b77836586d19ec2f32
+  ref: 7d9a85d0ee6a
+  submodules: true
   specs:
-    rsmp (0.1.14)
+    rsmp (0.1.15)
       async (~> 1.23.0)
       async-io (~> 1.27.4)
       colorize (~> 0.8.1)
@@ -15,7 +18,7 @@ GEM
       console (~> 1.0)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-io (1.27.4)
+    async-io (1.27.5)
       async (~> 1.14)
     colorize (0.8.1)
     console (1.8.2)

--- a/config/dynniq.yaml
+++ b/config/dynniq.yaml
@@ -10,10 +10,12 @@ supervisor:
       emergency_route:
         - '1'
       components:
-        :any:
-          traffic_controller: 'KK+AG9998=001TC000'
-          signal_group_prefix: 'KK+AG9998=001SG'
-          detector_logic_prefix: 'KK+AG9998=001DL'
+        main:
+          KK+AG9998=001TC000:
+        signal_group:
+          KK+AG9998=001SG001:
+        detector_logic:
+          KK+AG9998=001DL001:
   watchdog_interval: 60
   watchdog_timeout: 120
   acknowledgement_timeout: 20

--- a/config/dynniq.yaml
+++ b/config/dynniq.yaml
@@ -2,13 +2,13 @@ supervisor:
   sites:
     :any:
       plans:
-        - '3'
-        - '4'
-      traffic_situation:
-        - '1'
-        - '2'
-      emergency_route:
-        - '1'
+        - 3
+        - 4
+      traffic_situations:
+        - 1
+        - 2
+      emergency_routes:
+        - 1
       components:
         main:
           KK+AG9998=001TC000:

--- a/config/ruby.yaml
+++ b/config/ruby.yaml
@@ -26,9 +26,9 @@ supervisor:
   status_response_timeout: 0.1
   status_update_timeout: 0.1
 
-connect_timeout: 1
+connect_timeout: 0.2
 ready_timeout: 0.1
-command_timeout: 10.1
+command_timeout: 0.1
 status_timeout: 0.1
 subscribe_timeout: 0.1
 alarm_timeout: 0.1

--- a/config/ruby.yaml
+++ b/config/ruby.yaml
@@ -1,6 +1,14 @@
 supervisor:
   sites:
     :any:
+      plans:
+        - 1
+        - 2
+      traffic_situations:
+        - 1
+        - 2
+      emergency_routes:
+        - 1
       components:
         main:
           TC:
@@ -20,7 +28,8 @@ supervisor:
 
 connect_timeout: 1
 ready_timeout: 0.1
-
-command_timeout: 0.1
+command_timeout: 10.1
 status_timeout: 0.1
 subscribe_timeout: 0.1
+alarm_timeout: 0.1
+shutdown_timeout: 0.1

--- a/config/ruby.yaml
+++ b/config/ruby.yaml
@@ -1,12 +1,14 @@
 supervisor:
   sites:
     :any:
-      plans:
-        - '1'
-        - '2'
       components:
-        TC:
-          type: main
+        main:
+          TC:
+        signal_group:
+          A1:
+          A2:
+          B1:
+          B2:
   watchdog_interval: 1
   watchdog_timeout: 2
   acknowledgement_timeout: 0.1

--- a/config/ruby.yaml
+++ b/config/ruby.yaml
@@ -9,6 +9,8 @@ supervisor:
           A2:
           B1:
           B2:
+        detector_logic:
+          DL1:
   watchdog_interval: 1
   watchdog_timeout: 2
   acknowledgement_timeout: 0.1

--- a/config/swarco.yaml
+++ b/config/swarco.yaml
@@ -2,13 +2,13 @@ supervisor:
   sites:
     :any:
       plans:
-        - '8'
-        - '9'
-      traffic_situation:
-        - '1'
-        - '2'
-      emergency_route:
-        - '1'
+        - 8
+        - 9
+      traffic_situations:
+        - 1
+        - 2
+      emergency_routes:
+        - 1
       components:
         main:
           KK+AG9998=001TC000:

--- a/config/swarco.yaml
+++ b/config/swarco.yaml
@@ -10,10 +10,13 @@ supervisor:
       emergency_route:
         - '1'
       components:
-        :any:
-          traffic_controller: 'KK+AG9998=001TC000'
-          signal_group_prefix: 'KK+AG9998=001SG'
-          detector_logic_prefix: 'KK+AG9998=001DL'
+        main:
+          KK+AG9998=001TC000:
+        signal_group:
+          KK+AG9998=001SG001:
+        detector_logic:
+          KK+AG9998=001DL001:
+  watchdog_interval: 60
   watchdog_interval: 60
   watchdog_timeout: 120
   acknowledgement_timeout: 20

--- a/spec/site/alarm_spec.rb
+++ b/spec/site/alarm_spec.rb
@@ -2,18 +2,19 @@ RSpec.describe 'RSMP site alarm' do
   it 'A0301 detector error (hardware)' do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = COMPONENT_CONFIG['detector_logic_prefix'] + "001"
-
-      site.log "Waiting for alarm", level: :test
-      start_time = Time.now
-      message, response = nil,nil
-      expect do
-        response = site.wait_for_alarm component: component, aCId: 'A0301',
-          aSp: 'Issue', aS: 'Active', timeout: RSMP_CONFIG['alarm_timeout']
-      end.to_not raise_error, "Did not receive alarm"
-      
-      delay = Time.now - start_time
-      site.log "alarm confirmed after #{delay.to_i}s", level: :test
+      component = COMPONENT_CONFIG['detector_logic'].keys.first
+      if ask_user site, "Please activate detector error on equipment. Press enter when done or 'n' to skip test: ".colorize(:color => :light_magenta)
+        site.log "Waiting for alarm", level: :test
+        start_time = Time.now
+        message, response = nil,nil
+        expect do
+          response = site.wait_for_alarm component: component, aCId: 'A0301',
+            aSp: 'Issue', aS: 'Active', timeout: RSMP_CONFIG['alarm_timeout']
+        end.to_not raise_error, "Did not receive alarm"
+        
+        delay = Time.now - start_time
+        site.log "alarm confirmed after #{delay.to_i}s", level: :test
+      end
     end
   end
 end

--- a/spec/site/alarm_spec.rb
+++ b/spec/site/alarm_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'RSMP site alarm' do
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
       component = COMPONENT_CONFIG['detector_logic'].keys.first
-      if ask_user site, "Please activate detector error on equipment. Press enter when done or 'n' to skip test: ".colorize(:color => :light_magenta)
+      if ask_user site, "Please activate detector error on equipment. Press enter when ready or 's' to skip: ".colorize(:color => :light_magenta)
         site.log "Waiting for alarm", level: :test
         start_time = Time.now
         message, response = nil,nil

--- a/spec/site/command_spec.rb
+++ b/spec/site/command_spec.rb
@@ -409,7 +409,7 @@ def prepare task, site
   unsubscribe_from_all
 end
 
-RSpec.describe 'RSMP site commands' do
+RSpec.describe 'RSMP site commands' do  
   it 'M0001 set yellow flash' do |example|
     TestSite.log_test_header example
     TestSite.isolated do |task,supervisor,site|

--- a/spec/site/command_spec.rb
+++ b/spec/site/command_spec.rb
@@ -450,7 +450,7 @@ RSpec.describe 'RSMP site commands' do
       prepare task, site
       #if ask_user site, "Going to restart controller. Press enter when ready or 's' to skip:"
       set_restart
-      expect { site.wait_for_state :stopped, 100 }.to_not raise_error
+      expect { site.wait_for_state :stopped, RSMP_CONFIG['shutdown_timeout'] }.to_not raise_error
     end
     # NOTE
     # when a remote site closes the connection, our site proxy object will stop.

--- a/spec/site/command_spec.rb
+++ b/spec/site/command_spec.rb
@@ -46,7 +46,7 @@ def set_plan plan
   @site.send_command @component, [
     {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'status', 'v' => status},
     {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'securityCode', 'v' => security_code},
-    {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'timeplan', 'v' => plan}
+    {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'timeplan', 'v' => plan.to_s}
   ]
 
   log_confirmation "intention to switch to plan #{plan}" do
@@ -62,7 +62,7 @@ def set_plan plan
     expect(response.attributes['rvs']).to eq([
       { 'cCI' => command_code_id, 'n' => 'status','v' => status, 'age' => age },
       { 'cCI' => command_code_id, 'n' => 'securityCode','v' => security_code, 'age' => age },
-      { 'cCI' => command_code_id, 'n' => 'timeplan','v' => plan, 'age' => age }
+      { 'cCI' => command_code_id, 'n' => 'timeplan','v' => plan.to_s, 'age' => age }
     ])
   end
 end
@@ -250,41 +250,42 @@ def set_input status, input
   end
 end
 
-def set_detector_logic status
+def force_detector_logic component, status, value='True'
   security_code = SECRETS['security_codes'][2]
 
-  @site.log "Set detector logic", level: :test
+  @site.log "Force detector logic", level: :test
   command_code_id = 'M0008'
   command_name = 'setForceDetectorLogic'
-  @site.send_command @component, [
+
+  @site.send_command component, [
     {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'status', 'v' => status},
     {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'securityCode', 'v' => security_code},
-    {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'mode', 'v' => status}
+    {'cCI' => command_code_id, 'cO' => command_name, 'n' => 'mode', 'v' => value}
   ]
 
-  log_confirmation "intention to set detector logic" do
+  log_confirmation "intention to force detector logic" do
     response = nil
     expect do
-      response = @site.wait_for_command_response component: @component, timeout: RSMP_CONFIG['command_timeout']
+      response = @site.wait_for_command_response component: component, timeout: RSMP_CONFIG['command_timeout']
     end.to_not raise_error
 
     expect(response).to be_a(RSMP::CommandResponse)
-    expect(response.attributes['cId']).to eq(@component)
+    expect(response.attributes['cId']).to eq(component)
 
     age = 'recent'
     expect(response.attributes['rvs']).to eq([
       { 'cCI' => command_code_id, 'n' => 'status','v' => status, 'age' => age },
       { 'cCI' => command_code_id, 'n' => 'securityCode','v' => security_code, 'age' => age },
-      { 'cCI' => command_code_id, 'n' => 'mode','v' => status, 'age' => age }
+      { 'cCI' => command_code_id, 'n' => 'mode','v' => value, 'age' => age }
     ])
   end
 end
 
 def switch_plan plan
-  set_plan plan
+  set_plan plan.to_s
   verify_status(**{
     description: "switch to plan #{plan}",
-    status_list: [{'sCI'=>'S0014','n'=>'status','status'=>plan}]
+    status_list: [{'sCI'=>'S0014','n'=>'status','status'=>plan.to_s}]
   })
 end
 
@@ -314,7 +315,7 @@ def switch_yellow_flash
   set_functional_position 'YellowFlash'
   verify_status(**{
     description:"switch to yellow flash",
-    status_list:[{'sCI'=>'S0011','n'=>'status','status'=>'^True(,True)+$','regex'=>1}]
+    status_list:[{'sCI'=>'S0011','n'=>'status','status'=>'^True(,True)*$','regex'=>1}]
   })
 end
 
@@ -322,7 +323,7 @@ def switch_dark_mode
   set_functional_position 'Dark'
   verify_status(**{
     description:"switch to dark mode",
-    status_list:[{'sCI'=>'S0007','n'=>'status','status'=>'^False(,False)+$','regex'=>1}]
+    status_list:[{'sCI'=>'S0007','n'=>'status','status'=>'^False(,False)*$','regex'=>1}]
   })
 end
 
@@ -330,13 +331,13 @@ def wait_normal_control
   # Wait for 'switched on' to be true (dark mode false)
   verify_status(**{
     description:"dark mode off",
-    status_list:[{'sCI'=>'S0007','n'=>'status','status'=>'^True(,True)+$','regex'=>1}]
+    status_list:[{'sCI'=>'S0007','n'=>'status','status'=>'^True(,True)*$','regex'=>1}]
   })
 
   # Wait for yellow flash status to be false
   verify_status(**{
     description:"yellow flash off",
-    status_list:[{'sCI'=>'S0011','n'=>'status','status'=>'^False(,False)+$','regex'=>1}]
+    status_list:[{'sCI'=>'S0011','n'=>'status','status'=>'^False(,False)*$','regex'=>1}]
   })
 
   # Wait for startup mode to be false
@@ -355,7 +356,7 @@ end
 
 def switch_fixed_time status
   set_fixed_time status
-  match = '^' + status + '(,' + status + ')+$'
+  match = '^' + status + '(,' + status + ')*$'
   verify_status(**{
     description:"switch to fixed time #{status}",
     status_list:[{'sCI'=>'S0009','n'=>'status','status'=>match,'regex'=>1}]
@@ -372,6 +373,7 @@ def switch_emergency_route route
     description:"activate emergency route #{route}",
     status_list:[{'sCI'=>'S0006','n'=>'emergencystage','status'=>route}]
   })
+
   set_emergency_route 'False',route
   verify_status(**{
     description:"deactivate emergency route",
@@ -379,40 +381,43 @@ def switch_emergency_route route
   })
 end
 
-def switch_input input
-  set_input 'True',input
+def switch_input
+  input_index = 0
+  set_input 'True',input_index.to_s
 
-  prefix_num = input.to_i - 1
-  match = "^[0-1]{" + prefix_num.to_s + "}1([0-1])*$"
+  match = "^.{#{input_index}}1"
   verify_status(**{
-    description:"activate input #{input}",
+    description:"activate input #{input_index}",
     status_list:[{'sCI'=>'S0003','n'=>'inputstatus','status'=>match,'regex'=>1}]
   })
-  set_input 'False',input
-  match = "^[0-1]{" + prefix_num.to_s + "}0([0-1])*$"
+  set_input 'False',input_index.to_s
+  match = "^.{#{input_index}}0"
   verify_status(**{
-    description:"deactivate input #{input}",
+    description:"deactivate input #{input_index}",
     status_list:[{'sCI'=>'S0003','n'=>'inputstatus','status'=>match,'regex'=>1}]
   })
 end
 
-def switch_detector_logic dl
-  @component = COMPONENT_CONFIG['detector_logic_prefix'] + "006"
-  set_detector_logic 'True'
+def switch_detector_logic
+  detector_logic_index = 0
+  component = COMPONENT_CONFIG['detector_logic'].keys[detector_logic_index]
 
-  prefix_num = dl.to_i - 1
-  match = "^[0-1]{" + prefix_num.to_s + "}1([0-1])*$"
+  force_detector_logic component, 'True', 'True'
+
+  match = "^.{#{detector_logic_index}}1"
   @component = MAIN_COMPONENT
   verify_status(**{
-    description:"activate detector logic #{dl}",
+    description:"activate detector logic #{component}",
     status_list:[{'sCI'=>'S0002','n'=>'detectorlogicstatus','status'=>match,'regex'=>1}]
   })
-  @component = COMPONENT_CONFIG['detector_logic_prefix'] + "006"
-  set_detector_logic 'False'
-  match = "^[0-1]{" + prefix_num.to_s + "}0([0-1])*$"
+  
+
+  force_detector_logic component, 'False'
+  
+  match = "^.{#{detector_logic_index}}0"
   @component = MAIN_COMPONENT
   verify_status(**{
-    description:"deactivate detector logic #{dl}",
+    description:"deactivate detector logic #{component}",
     status_list:[{'sCI'=>'S0002','n'=>'detectorlogicstatus','status'=>match,'regex'=>1}]
   })
 end
@@ -455,7 +460,7 @@ RSpec.describe 'RSMP site commands' do
     TestSite.log_test_header example
     TestSite.isolated do |task,supervisor,site|
       prepare task, site
-      SITE_CONFIG['traffic_situation'].each { |ts| switch_traffic_situation ts }
+      SITE_CONFIG['traffic_situations'].each { |ts| switch_traffic_situation ts.to_s }
     end
   end
 
@@ -463,24 +468,22 @@ RSpec.describe 'RSMP site commands' do
     TestSite.log_test_header example
     TestSite.isolated do |task,supervisor,site|
       prepare task, site
-      print "Testing traffic controller restart. Enter 'y' to continue, 'n' to skip: "
-      response = $stdin.gets.chomp
-      expect(response).to eq('y')
-
-      set_restart
-      expect { site.wait_for_state :stopping, 120}.to_not raise_error
+      if ask_user site, "Going to restart controller. Press enter to continue or 'n' to skip test:"
+        set_restart
+        #expect { site.wait_for_state :stopping, RSMP_CONFIG['shutdown_timeout'] }.to_not raise_error
+        wait_normal_control
+      end
     end
-    TestSite.isolated do |task,supervisor,site|
-      prepare task, site
-      wait_normal_control
-    end
+    #TestSite.isolated do |task,supervisor,site|
+      #prepare task, site
+    #end
   end
 
   it 'M0005 activate emergency route' do |example|
     TestSite.log_test_header example
     TestSite.isolated do |task,supervisor,site|
       prepare task, site
-      SITE_CONFIG['emergency_route'].each { |route| switch_emergency_route route }
+      SITE_CONFIG['emergency_routes'].each { |route| switch_emergency_route route.to_s }
     end
   end
 
@@ -489,7 +492,7 @@ RSpec.describe 'RSMP site commands' do
     TestSite.isolated do |task,supervisor,site|
       prepare task, site
       unsubscribe_from_all
-      switch_input '6'
+      switch_input
     end
   end
 
@@ -506,7 +509,7 @@ RSpec.describe 'RSMP site commands' do
     TestSite.log_test_header example
     TestSite.isolated do |task,supervisor,site|
       prepare task, site
-      switch_detector_logic '6'
+      switch_detector_logic 
     end
   end
 end

--- a/spec/site/status_spec.rb
+++ b/spec/site/status_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "RSMP site status" do
+  status_response_timeout = SUPERVISOR_CONFIG['status_response_timeout']
+
   it 'S0001 signal group status' do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
@@ -14,7 +16,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'cyclecounter'},
           {'sCI'=>status_code,'n'=>'basecyclecounter'},
           {'sCI'=>status_code,'n'=>'stage'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -44,7 +46,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'detectorlogicstatus'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -74,7 +76,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'inputstatus'},
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -104,7 +106,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'outputstatus'},
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -134,7 +136,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -165,7 +167,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'emergencystage'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -196,7 +198,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -227,7 +229,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -258,7 +260,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -289,7 +291,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -320,7 +322,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -351,7 +353,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -380,7 +382,7 @@ RSpec.describe "RSMP site status" do
       start_time = Time.now
       message, response = nil,nil
       expect do
-        message, response = site.request_status component, [{'sCI'=>status_code,'n'=>status_name}], STATUS_RESPONSE_TIMEOUT
+        message, response = site.request_status component, [{'sCI'=>status_code,'n'=>status_name}], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -413,7 +415,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -443,7 +445,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -473,7 +475,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -503,7 +505,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -533,7 +535,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -563,7 +565,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -594,7 +596,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'controlmode'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -624,7 +626,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'detectorlogics'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -654,7 +656,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -684,7 +686,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -714,7 +716,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -751,7 +753,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'maxToREstimate'},
           {'sCI'=>status_code,'n'=>'likelyToREstimate'},
           {'sCI'=>status_code,'n'=>'ToRConfidence'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -781,7 +783,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -811,7 +813,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -842,7 +844,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -872,7 +874,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -903,7 +905,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'user'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -934,7 +936,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'user'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -964,7 +966,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -999,7 +1001,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'hour'},
           {'sCI'=>status_code,'n'=>'minute'},
           {'sCI'=>status_code,'n'=>'second'},
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1030,7 +1032,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'vehicles'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1061,7 +1063,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'speed'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1092,7 +1094,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'occupancy'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1131,7 +1133,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'MC'},
           {'sCI'=>status_code,'n'=>'C'},
           {'sCI'=>status_code,'n'=>'F'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1162,7 +1164,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'vehicles'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1193,7 +1195,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'speed'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1224,7 +1226,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'occupancy'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1263,7 +1265,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'MC'},
           {'sCI'=>status_code,'n'=>'C'},
           {'sCI'=>status_code,'n'=>'F'}
-        ], STATUS_RESPONSE_TIMEOUT
+        ], status_response_timeout
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"

--- a/spec/site/status_spec.rb
+++ b/spec/site/status_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[a-hA-G0-9NOP]*$/) if sS["n"] == 'signalgroupstatus'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'cyclecounter'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'basecyclecounter'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'stage'
       end
     end
   end
@@ -62,7 +58,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'detectorlogicstatus'
       end
     end
   end
@@ -93,7 +88,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'inputstatus'
       end
     end
   end
@@ -124,7 +118,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'outputstatus'
       end
     end
   end
@@ -155,7 +148,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False$/) if sS["n"] == 'status'
       end
     end
   end
@@ -187,8 +179,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[1-9]+$/) if sS["n"] == 'emergencystage'
       end
     end
   end
@@ -220,8 +210,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False(,True|False)*$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[1-9](,[1-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -253,8 +241,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False(,True|False)*$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[0-9](,[0-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -286,8 +272,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False(,True|False)*$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[0-9](,[0-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -319,8 +303,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False(,True|False)*$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[0-9](,[0-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -352,8 +334,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False(,True|False)*$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[0-9](,[0-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -385,8 +365,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^True|False(,True|False)*$/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^[0-9](,[0-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -419,7 +397,6 @@ RSpec.describe "RSMP site status" do
       expect(item["sCI"]).to eq(status_code)
       expect(item["n"]).to eq(status_name)
 
-      expect(item["s"]).to match(/^[0-2](,[0-2])*$/)
       expect(item["q"]).to eq('recent')
     end
   end
@@ -450,7 +427,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -481,7 +457,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -512,7 +487,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'number'
       end
     end
   end
@@ -543,7 +517,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'number'
       end
     end
   end
@@ -574,7 +547,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'number'
       end
     end
   end
@@ -605,7 +577,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'number'
       end
     end
   end
@@ -637,8 +608,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^startup|control|standby|failure|test(,startup|control|standby|failure|test)*$/) if sS["n"] == 'controlmode'
-        expect(sS["s"]).to match(/^[0-9](,[0-9])*$/) if sS["n"] == 'intersection'
       end
     end
   end
@@ -669,7 +638,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-1]+$/) if sS["n"] == 'detectorlogics'
       end
     end
   end
@@ -700,7 +668,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9](,[0-9])+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -731,7 +698,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{2}-[0-9]{2}-[0-9]{2}(,[0-9]{2}-[0-9]{2}-[0-9]{2})+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -762,7 +728,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{2}-[0-9]{2}(,[0-9]{2}-[0-9]{2})+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -800,9 +765,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        if sS["n"].match(/minToGEstimate|maxToGEstimate|likelyToGEstimate|likelyToGEstimate|ToGConfidence|minToREstimate|maxToREstimate|likelyToREstimate|likelyToREstimate|ToRConfidence/)
-           expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/)
-        end
       end
     end
   end
@@ -833,7 +795,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]-[0-9](,[0-9]-[0-9])+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -864,9 +825,9 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]-[0-9]-[0-9]-[0-9](,[0-9]-[0-9]-[0-9]-[0-9])+$/) if sS["n"] == 'status'
       end
     end
+
   end
 
   it 'S0028 cycle time' do |example|
@@ -895,7 +856,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+-[0-9]+-(,[0-9]+-[0-9])+$/) if sS["n"] == 'status'
       end
     end
   end
@@ -926,7 +886,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]+/) if sS["n"] == 'status'
       end
     end
   end
@@ -958,8 +917,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/login|logout/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^.*$/) if sS["n"] == 'user'
       end
     end
   end
@@ -991,8 +948,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/login|logout/) if sS["n"] == 'status'
-        expect(sS["s"]).to match(/^.*$/) if sS["n"] == 'user'
       end
     end
   end
@@ -1023,7 +978,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).not_to match(/^$/) if sS["n"] == 'status'
       end
     end
   end
@@ -1059,12 +1013,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}$/) if sS["n"] == 'year'
-        expect(sS["s"]).to match(/^[0-9]{1,2}$/) if sS["n"] == 'month'
-        expect(sS["s"]).to match(/^[0-9]{1,2}$/) if sS["n"] == 'day'
-        expect(sS["s"]).to match(/^[0-9]{1,2}$/) if sS["n"] == 'hour'
-        expect(sS["s"]).to match(/^[0-9]{2}$/) if sS["n"] == 'minute'
-        expect(sS["s"]).to match(/^[0-9]{2}$/) if sS["n"] == 'second'
       end
     end
   end
@@ -1096,8 +1044,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'vehicles'
       end
     end
   end
@@ -1129,8 +1075,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'speed'
       end
     end
   end
@@ -1162,8 +1106,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'occupancy'
       end
     end
   end
@@ -1203,16 +1145,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'P'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'PS'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'L'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'LS'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'B'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'SP'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'MC'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'C'
-        expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'F'
       end
     end
   end
@@ -1244,8 +1176,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'vehicles'
       end
     end
   end
@@ -1277,8 +1207,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'speed'
       end
     end
   end
@@ -1310,8 +1238,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'occupancy'
       end
     end
   end
@@ -1351,16 +1277,6 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'P'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'PS'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'L'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'LS'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'B'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'SP'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'MC'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'C'
-        expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'F'
       end
     end
   end

--- a/spec/site/status_spec.rb
+++ b/spec/site/status_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'cyclecounter'},
           {'sCI'=>status_code,'n'=>'basecyclecounter'},
           {'sCI'=>status_code,'n'=>'stage'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -44,7 +44,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'detectorlogicstatus'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -74,7 +74,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'inputstatus'},
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -104,7 +104,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'outputstatus'},
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -134,7 +134,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -165,7 +165,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'emergencystage'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -196,7 +196,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -227,7 +227,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -258,7 +258,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -289,7 +289,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -320,7 +320,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -351,7 +351,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -380,7 +380,7 @@ RSpec.describe "RSMP site status" do
       start_time = Time.now
       message, response = nil,nil
       expect do
-        message, response = site.request_status component, [{'sCI'=>status_code,'n'=>status_name}], 180
+        message, response = site.request_status component, [{'sCI'=>status_code,'n'=>status_name}], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -413,7 +413,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -443,7 +443,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -473,7 +473,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -503,7 +503,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -533,7 +533,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -563,7 +563,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'number'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -594,7 +594,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'controlmode'},
           {'sCI'=>status_code,'n'=>'intersection'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -624,7 +624,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'detectorlogics'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -654,7 +654,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -684,7 +684,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -714,7 +714,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -735,7 +735,7 @@ RSpec.describe "RSMP site status" do
   it 'S0025 time-of-green/time-of-red' do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = COMPONENT_CONFIG['signal_group_prefix'] + "001"
+      component = COMPONENT_CONFIG['signal_group'].keys.first
       status_code = 'S0025'
 
       site.log "Requesting time-of-green/time-of-red", level: :test
@@ -751,7 +751,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'maxToREstimate'},
           {'sCI'=>status_code,'n'=>'likelyToREstimate'},
           {'sCI'=>status_code,'n'=>'ToRConfidence'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -781,7 +781,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -811,7 +811,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -842,7 +842,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -872,7 +872,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -903,7 +903,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'user'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -934,7 +934,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'},
           {'sCI'=>status_code,'n'=>'user'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -964,7 +964,7 @@ RSpec.describe "RSMP site status" do
       expect do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'status'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -999,7 +999,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'hour'},
           {'sCI'=>status_code,'n'=>'minute'},
           {'sCI'=>status_code,'n'=>'second'},
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1020,7 +1020,7 @@ RSpec.describe "RSMP site status" do
   it 'S0201 traffic counting: number of vehicles'  do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = COMPONENT_CONFIG['detector_logic_prefix'] + "001"
+      component = COMPONENT_CONFIG['detector_logic'].keys.first
       status_code = 'S0201'
 
       site.log "Requesting traffic counting: number of vehicles", level: :test
@@ -1028,9 +1028,9 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'start'},
+          {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'vehicles'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1051,7 +1051,7 @@ RSpec.describe "RSMP site status" do
   it 'S0202 traffic counting: vehicle speed' do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = COMPONENT_CONFIG['detector_logic_prefix'] + "001"
+      component = COMPONENT_CONFIG['detector_logic'].keys.first
       status_code = 'S0202'
 
       site.log "Requesting traffic counting: vehicle speed", level: :test
@@ -1059,9 +1059,9 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'start'},
+          {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'speed'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1082,7 +1082,7 @@ RSpec.describe "RSMP site status" do
   it 'S0203 traffic counting: occupancy'  do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = COMPONENT_CONFIG['detector_logic_prefix'] + "001"
+      component = COMPONENT_CONFIG['detector_logic'].keys.first
       status_code = 'S0203'
 
       site.log "Requesting traffic counting: occupancy", level: :test
@@ -1090,9 +1090,9 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'start'},
+          {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'occupancy'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1113,7 +1113,7 @@ RSpec.describe "RSMP site status" do
   it 'S0204 traffic counting: classification' do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = COMPONENT_CONFIG['detector_logic_prefix'] + "001"
+      component = COMPONENT_CONFIG['detector_logic'].keys.first
       status_code = 'S0204'
 
       site.log "Requesting traffic counting: classification", level: :test
@@ -1121,7 +1121,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'start'},
+          {'sCI'=>status_code,'n'=>'starttime'},
           {'sCI'=>status_code,'n'=>'P'},
           {'sCI'=>status_code,'n'=>'PS'},
           {'sCI'=>status_code,'n'=>'L'},
@@ -1131,7 +1131,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'MC'},
           {'sCI'=>status_code,'n'=>'C'},
           {'sCI'=>status_code,'n'=>'F'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1162,7 +1162,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'vehicles'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1193,7 +1193,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'speed'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1224,7 +1224,7 @@ RSpec.describe "RSMP site status" do
         message, response = site.request_status component,[
           {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'occupancy'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
@@ -1263,7 +1263,7 @@ RSpec.describe "RSMP site status" do
           {'sCI'=>status_code,'n'=>'MC'},
           {'sCI'=>status_code,'n'=>'C'},
           {'sCI'=>status_code,'n'=>'F'}
-        ], 180
+        ], STATUS_RESPONSE_TIMEOUT
       end.not_to raise_error
 
       expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"

--- a/spec/site/status_spec.rb
+++ b/spec/site/status_spec.rb
@@ -1080,7 +1080,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'vehicles'}
         ], 180
       end.not_to raise_error
@@ -1096,7 +1096,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'vehicles'
       end
     end
@@ -1113,7 +1113,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'speed'}
         ], 180
       end.not_to raise_error
@@ -1129,7 +1129,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'speed'
       end
     end
@@ -1146,7 +1146,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'occupancy'}
         ], 180
       end.not_to raise_error
@@ -1162,7 +1162,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'occupancy'
       end
     end
@@ -1179,7 +1179,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'P'},
           {'sCI'=>status_code,'n'=>'PS'},
           {'sCI'=>status_code,'n'=>'L'},
@@ -1203,7 +1203,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'P'
         expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'PS'
         expect(sS["s"]).to match(/^[0-9]+$/) if sS["n"] == 'L'
@@ -1228,7 +1228,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'vehicles'}
         ], 180
       end.not_to raise_error
@@ -1244,7 +1244,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'vehicles'
       end
     end
@@ -1261,7 +1261,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'speed'}
         ], 180
       end.not_to raise_error
@@ -1277,7 +1277,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'speed'
       end
     end
@@ -1294,7 +1294,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'occupancy'}
         ], 180
       end.not_to raise_error
@@ -1310,7 +1310,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'occupancy'
       end
     end
@@ -1327,7 +1327,7 @@ RSpec.describe "RSMP site status" do
       message, response = nil,nil
       expect do
         message, response = site.request_status component,[
-          {'sCI'=>status_code,'n'=>'starttime'},
+          {'sCI'=>status_code,'n'=>'start'},
           {'sCI'=>status_code,'n'=>'P'},
           {'sCI'=>status_code,'n'=>'PS'},
           {'sCI'=>status_code,'n'=>'L'},
@@ -1351,7 +1351,7 @@ RSpec.describe "RSMP site status" do
 
       response.attributes["sS"].each do |sS|
         expect(sS["q"]).to eq('recent')
-        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'starttime'
+        expect(sS["s"]).to match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$/) if sS["n"] == 'start'
         expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'P'
         expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'PS'
         expect(sS["s"]).to match(/^[0-9]+(,[0-9]+)+$/) if sS["n"] == 'L'

--- a/spec/site/subscribe_spec.rb
+++ b/spec/site/subscribe_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "RSMP site status" do
   it 'responds to valid status request' do |example|
     TestSite.log_test_header example
     TestSite.connected do |task,supervisor,site|
-      component = 'KK+AG9998=001TC000'
+      component = MAIN_COMPONENT
       status_code = 'S0001'
       status_name = 'signalgroupstatus'
 

--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -53,6 +53,7 @@ SUPERVISOR_CONFIG = RSMP_CONFIG['supervisor'] rescue {}
 SITE_CONFIG = SUPERVISOR_CONFIG['sites'].values.first rescue {}
 COMPONENT_CONFIG = SITE_CONFIG['components'] rescue {}
 MAIN_COMPONENT = COMPONENT_CONFIG['main'].keys.first
+STATUS_RESPONSE_TIMEOUT = SUPERVISOR_CONFIG['status_response_timeout']
 
 puts "Using test config #{VALIDATOR_CONFIG['rsmp_config_path']}"
 

--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -26,19 +26,16 @@ def load_secrets path
 	secrets = YAML.load_file(secrets_path)
 
 	required_keys = ['security_codes']
-	required_keys.each { |key| verify_presence_of_secret secrets, secrets_path, key }
+	required_keys.each do |key|
+		unless secrets[key]
+			puts "The key '#{key}' is missing from #{secrets_path}. Please add it and try again."
+			exit
+		end
+	end
 	secrets
 end
 
-def verify_presence_of_secret secrets, secrets_path, key
-	unless secrets[key]
-		puts "The key '#{key}' is missing from #{secrets_path}. Please add it and try again."
-		exit
-	end
-end
-
-
- def ask_user site, question, accept:''
+def ask_user site, question, accept:''
 	pointing = "\u{1f449}"
 	print "#{pointing} " + question.colorize(:color => :light_magenta) + " "
 	site.log "Asking user for input: #{question}", level: :test
@@ -49,27 +46,51 @@ end
 		site.log "Test skipped by user", level: :test
 		expect(response).to eq(accept), "Test skipped by user"
 	end
- end
-
+end
 
 ASYNC_STDIN = Async::IO::Stream.new( Async::IO::Generic.new($stdin) )
 
-VALIDATOR_CONFIG = YAML.load_file 'config/validator.yaml' rescue {}
+validator_config = YAML.load_file 'config/validator.yaml'
+raise "Error: File config/validator.yaml is missing" unless validator_config
 
-rsmp_config_path = VALIDATOR_CONFIG['rsmp_config_path']
-rsmp_config_path = 'config/ruby.yaml' unless rsmp_config_path
+rsmp_config_path = validator_config['rsmp_config_path'] || 'config/ruby.yaml'
 RSMP_CONFIG = YAML.load_file rsmp_config_path
+puts "Using test config #{rsmp_config_path}"
 
-LOG_CONFIG = YAML.load_file VALIDATOR_CONFIG['log_config_path'] rescue {}
+if validator_config['log_config_path']
+	LOG_CONFIG = YAML.load_file validator_config['log_config_path'] 
+else
+	LOG_CONFIG = {}
+end
 
 SECRETS = load_secrets 'config/secrets.yaml'
 
 #sugar
 SUPERVISOR_CONFIG = RSMP_CONFIG['supervisor'] rescue {}
-SITE_CONFIG = SUPERVISOR_CONFIG['sites'].values.first rescue {}
-COMPONENT_CONFIG = SITE_CONFIG['components'] rescue {}
-MAIN_COMPONENT = COMPONENT_CONFIG['main'].keys.first
-STATUS_RESPONSE_TIMEOUT = SUPERVISOR_CONFIG['status_response_timeout']
+puts "Warning: #{rsmp_config_path} supervisor settings is missing or empty" if SUPERVISOR_CONFIG == {}
 
-puts "Using test config #{VALIDATOR_CONFIG['rsmp_config_path']}"
+SITE_CONFIG = SUPERVISOR_CONFIG['sites'].values.first rescue {}
+puts "Warning: #{rsmp_config_path} sites settings is missing or empty" if SITE_CONFIG == {}
+
+COMPONENT_CONFIG = SITE_CONFIG['components'] rescue {}
+puts "Warning: #{rsmp_config_path} components settings is missing or empty" if COMPONENT_CONFIG == {}
+
+
+MAIN_COMPONENT = COMPONENT_CONFIG['main'].keys.first rescue {}
+puts "Warning: #{rsmp_config_path} main component settings is missing or empty" if MAIN_COMPONENT == {}
+
+
+# check required configs
+required = [
+	'connect_timeout',
+	'ready_timeout',
+	'command_timeout',
+	'status_timeout',
+	'subscribe_timeout',
+	'alarm_timeout',
+	'shutdown_timeout'
+]
+required.each do |key|
+	raise "Config #{key} is missing from #{rsmp_config_path}" unless RSMP_CONFIG[key]
+end
 

--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -38,6 +38,22 @@ def verify_presence_of_secret secrets, secrets_path, key
 end
 
 
+ def ask_user site, question, accept:''
+	pointing = "\u{1f449}"
+	print "#{pointing} " + question.colorize(:color => :light_magenta) + " "
+	site.log "Asking user for input: #{question}", level: :test
+	response = ASYNC_STDIN.gets.chomp
+	if response == accept
+		site.log "OK from user", level: :test
+	else
+		site.log "Test skipped by user", level: :test
+		expect(response).to eq(accept), "Test skipped by user"
+	end
+ end
+
+
+ASYNC_STDIN = Async::IO::Stream.new( Async::IO::Generic.new($stdin) )
+
 VALIDATOR_CONFIG = YAML.load_file 'config/validator.yaml' rescue {}
 
 rsmp_config_path = VALIDATOR_CONFIG['rsmp_config_path']

--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -51,8 +51,8 @@ SECRETS = load_secrets 'config/secrets.yaml'
 #sugar
 SUPERVISOR_CONFIG = RSMP_CONFIG['supervisor'] rescue {}
 SITE_CONFIG = SUPERVISOR_CONFIG['sites'].values.first rescue {}
-COMPONENT_CONFIG = SITE_CONFIG['components'].values.first rescue {}
-MAIN_COMPONENT = COMPONENT_CONFIG['traffic_controller']
+COMPONENT_CONFIG = SITE_CONFIG['components'] rescue {}
+MAIN_COMPONENT = COMPONENT_CONFIG['main'].keys.first
 
 puts "Using test config #{VALIDATOR_CONFIG['rsmp_config_path']}"
 


### PR DESCRIPTION
A number or refactorings.

- fixes config format problems, now matches format used in rsmp gem
- use async stdin.gets when asking users for input, to avoid stalling rsmp processes
- remove hardcoded detector logic indexes
- remove regex checks on responses, it's covered by the schema validation
- fix regexes
- other fixes

Tested against the ruby TLC, but not yet against hardware