### PR TITLE
Surface exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '00272c1', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '9383b32', :submodules => true
 gem 'rspec'
 gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: 00272c121d4045bc1802ba3ae0d1a134fa200f4a
-  ref: 00272c1
+  revision: 9383b3296fb7eed6f64b60442f89c13bea8d7212
+  ref: 9383b32
   submodules: true
   specs:
     rsmp (0.1.25)

--- a/spec/support/test_site.rb
+++ b/spec/support/test_site.rb
@@ -16,8 +16,15 @@ class TestSite
 
     # use run() to continue the reactor. this will give as a new task,
     # which we run the rspec test inside
-    more = @reactor.run do |task|
+    @reactor.run do |task|
       task.annotate 'rspec runner'
+      task.async do |sentinel|
+        sentinel.annotate 'sentinel'
+        @supervisor.error_condition.wait  # if it's an exception, it will be raised
+      rescue => e
+        error = e
+        task.stop
+      end
       yield task              # run block until it's finished
     rescue StandardError, RSpec::Expectations::ExpectationNotMetError => e
       error = e               # catch and store errors
@@ -61,7 +68,7 @@ class TestSite
 
       # start the supervisor in a separe async task that will
       # persist across tests
-      @reactor.async do |task|
+      @supervisor_task = @reactor.async do |task|
         @supervisor = RSMP::Supervisor.new(
           task: task,
           supervisor_settings: supervisor_settings,

--- a/spec/support/test_site.rb
+++ b/spec/support/test_site.rb
@@ -150,7 +150,6 @@ class TestSite
     unless @remote_site
       @supervisor.log "Waiting for site to connect", level: :test
       @remote_site = @supervisor.wait_for_site(:any, RSMP_CONFIG['connect_timeout'])
-      expect(@remote_site).not_to be_nil, "Site did not connect within #{RSMP_CONFIG['connect_timeout']}s"
     end
     @remote_site.wait_for_state :ready, RSMP_CONFIG['ready_timeout']
   end


### PR DESCRIPTION
the rsmp gem catches errors and keeps on going, to avoid e.g an invalid mesage from stopping an rsmp supervisor. 
but it can now now notify about errors, and the rsmp_validator will now abort the currently active test if this happens.

receiving (or sending) a message with invalid json schema should now abort the current test.