### PR TITLE
Move Dynniq EC-2 action to Windows

### DIFF
--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -54,7 +54,7 @@ jobs:
         ip: ${{ secrets.EC2_IP }}
       run: |
         Remove-Item Alias:curl
-        $remote_path='ftp://$ip/tmp/proxyapp.log'
+        $remote_path='ftp://'+$ip+'/tmp/proxyapp.log'
         curl -u $user":"$passwd $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -25,7 +25,7 @@ jobs:
         "rsmp_config_path: config/ci/dynniq_ec2.yaml" | Out-File 'config/validator.yaml' -Encoding utf8
     - name: Set up secrets
       run: |
-        echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml
+        "security_codes:`n    1: ''`n    2: ''" | Out-File 'config/secrets.yaml' -Encoding utf8
     - name: Set up ruby
       uses: ruby/setup-ruby@v1
       env:

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -54,8 +54,8 @@ jobs:
         IP: ${{ secrets.EC2_IP }}
       run: |
         Remove-Item Alias:curl
-        $remote_path='ftp://'+'$env:IP'+'/tmp/proxyapp.log'
-        curl -u '$env:USER'+':'+'$env:PASSWD' $remote_path -o simulator.log
+        $remote_path='ftp://'+$env:IP+'/tmp/proxyapp.log'
+        curl -u $env:USER+':'+$env:PASSWD $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         Remove-Item Alias:curl
         $remote_path='ftp://'+$env:IP+'/tmp/proxyapp.log'
-        curl -u $env:USER+':'+$env:PASSWD $remote_path -o simulator.log
+        curl -u '$env:USER'+':'+'$env:PASSWD' $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Set up secrets
       run: |
         echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml
-    - name: Configure bundle
-      run: bundle config set path '~/rsmp_gems/bundle'
-    - name: Run bundle install
-      run: bundle install
+    - name: Set up ruby
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
       run: bundle exec rspec spec/site
     - name: Rename validation.log

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -50,7 +50,9 @@ jobs:
         user: ${{ secrets.EC2_USER }}
         passwd: ${{ secrets.EC2_PASSWD }}
         ip: ${{ secrets.EC2_IP }}
-      run: ncftpget -C -u "$user" -p "$passwd" "$ip" /tmp/proxyapp.log simulator.log
+      run: |
+        Remove-Item Alias:curl
+        curl -u $user":"$passwd ftp://$ip/tmp/proxyapp.log -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
 
-    runs-on: [ self-hosted, Linux, X64, ec2 ]
+    runs-on: [ self-hosted, Windows, X64, ec2 ]
     steps:
     - name: Check out repository
       uses: actions/checkout@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -25,7 +25,7 @@ jobs:
         echo "rsmp_config_path: config/ci/dynniq_ec2.yaml" > config/validator.yaml
     - name: Set up secrets
       run: |
-        echo -e "security_codes:\n    1: ''\n    2: ''" > config/secrets.yaml
+        echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml
     - name: Configure bundle
       run: bundle config set path '~/rsmp_gems/bundle'
     - name: Run bundle install

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -28,6 +28,8 @@ jobs:
         echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml
     - name: Set up ruby
       uses: ruby/setup-ruby@v1
+      env:
+        ImageOS: win19
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         ImageOS: win19
       with:
-        ruby-version: 2.6
+        ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
       run: bundle exec rspec spec/site

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Configure test
       run: |
-        "rsmp_config_path: config/ci/dynniq_ec2.yaml" | Out-File 'config/validator.yaml' - -Encoding utf8
+        "rsmp_config_path: config/ci/dynniq_ec2.yaml" | Out-File 'config/validator.yaml' -Encoding utf8
     - name: Set up secrets
       run: |
         echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -49,13 +49,13 @@ jobs:
     - name: Get ec2 rsmp log
       if: always()
       env:
-        user: ${{ secrets.EC2_USER }}
-        passwd: ${{ secrets.EC2_PASSWD }}
-        ip: ${{ secrets.EC2_IP }}
+        USER: ${{ secrets.EC2_USER }}
+        PASSWD: ${{ secrets.EC2_PASSWD }}
+        IP: ${{ secrets.EC2_IP }}
       run: |
         Remove-Item Alias:curl
-        $remote_path='ftp://'+$ip+'/tmp/proxyapp.log'
-        curl -u $user+':'+$passwd $remote_path -o simulator.log
+        $remote_path='ftp://'+'$env:IP'+'/tmp/proxyapp.log'
+        curl -u '$env:USER'+':'+'$env:PASSWD' $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -21,11 +21,9 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
     - name: Configure test
-      shell: bash
       run: |
         echo "rsmp_config_path: config/ci/dynniq_ec2.yaml" > config/validator.yaml
     - name: Set up secrets
-      shell: bash
       run: |
         echo -e "security_codes:\n    1: ''\n    2: ''" > config/secrets.yaml
     - name: Configure bundle

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -37,7 +37,9 @@ jobs:
       run: bundle exec rspec spec/site
     - name: Rename validation.log
       if: always()
-      run: mv log/validation.log log/validation_ec2_$(date +%F_%H-%M-%S).log
+      run: |
+        $date=Get-Date -Format 'yyyy-MM-dd_HH-mm'
+        mv log/validation.log log/validation_ec2_$date.log
     - name: Upload validation.log
       if: always()
       uses: actions/upload-artifact@v2
@@ -52,7 +54,8 @@ jobs:
         ip: ${{ secrets.EC2_IP }}
       run: |
         Remove-Item Alias:curl
-        curl -u $user":"$passwd "ftp://$ip/tmp/proxyapp.log" -o simulator.log
+        $remote_path='ftp://$ip/tmp/proxyapp.log'
+        curl -u $user":"$passwd $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml
     - name: Set up ruby
-    - uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -31,6 +31,7 @@ jobs:
       env:
         ImageOS: win19
       with:
+        ruby-version: 2.6
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
       run: bundle exec rspec spec/site

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -52,7 +52,7 @@ jobs:
         ip: ${{ secrets.EC2_IP }}
       run: |
         Remove-Item Alias:curl
-        curl -u $user":"$passwd ftp://$ip/tmp/proxyapp.log -o simulator.log
+        curl -u $user":"$passwd "ftp://$ip/tmp/proxyapp.log" -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Configure test
       run: |
-        echo "rsmp_config_path: config/ci/dynniq_ec2.yaml" > config/validator.yaml
+        "rsmp_config_path: config/ci/dynniq_ec2.yaml" | Out-File 'config/validator.yaml' - -Encoding utf8
     - name: Set up secrets
       run: |
         echo "security_codes:`n    1: ''`n    2: ''" > config/secrets.yaml

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         Remove-Item Alias:curl
         $remote_path='ftp://'+$ip+'/tmp/proxyapp.log'
-        curl -u $user":"$passwd $remote_path -o simulator.log
+        curl -u $user+':'+$passwd $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -55,7 +55,8 @@ jobs:
       run: |
         Remove-Item Alias:curl
         $remote_path='ftp://'+$env:IP+'/tmp/proxyapp.log'
-        curl -u '$env:USER'+':'+'$env:PASSWD' $remote_path -o simulator.log
+        $credentials=$env:USER+':'+$env:PASSWD
+        curl -u $credentials $remote_path -o simulator.log
     - name: Upload ec2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'a99db0a', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '9383b3296fb7ee', :submodules => true
 gem 'rspec'
 gem 'activesupport'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'acfd2217af38b534c05', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '8377da7', :submodules => true
 gem 'rspec'
 gem 'activesupport'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '8377da7', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'a99db0a', :submodules => true
 gem 'rspec'
 gem 'activesupport'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '9383b32', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'acfd2217af38b534c05', :submodules => true
 gem 'rspec'
 gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: acfd2217af38b534c050db801794243c1285a543
-  ref: acfd2217af38b534c05
+  revision: 8377da7467198f481f42a3296f81aeac9f0eaf9c
+  ref: 8377da7
   submodules: true
   specs:
     rsmp (0.1.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: 8377da7467198f481f42a3296f81aeac9f0eaf9c
-  ref: 8377da7
+  revision: a99db0a6c109f11b5966fe1d1a622f6eb9c1b16a
+  ref: a99db0a
   submodules: true
   specs:
     rsmp (0.1.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: 9383b3296fb7eed6f64b60442f89c13bea8d7212
-  ref: 9383b32
+  revision: acfd2217af38b534c050db801794243c1285a543
+  ref: acfd2217af38b534c05
   submodules: true
   specs:
     rsmp (0.1.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: a99db0a6c109f11b5966fe1d1a622f6eb9c1b16a
-  ref: a99db0a
+  revision: 9383b3296fb7eed6f64b60442f89c13bea8d7212
+  ref: 9383b3296fb7ee
   submodules: true
   specs:
     rsmp (0.1.25)


### PR DESCRIPTION
The EC-2 runner has recently been moved to the Windows platform. This requires several updates to the workflow

- [x] Use Powershell instead of bash (or make WSL work?)
- [x] Make Ruby work