### PR TITLE
Exceptions cleanup,  reactivate disconnect tests

### DIFF
--- a/config/ci/dynniq_ec2.yaml
+++ b/config/ci/dynniq_ec2.yaml
@@ -27,6 +27,7 @@ supervisor:
   status_update_timeout: 20
 
 connect_timeout: 60
+disconnect_timeout: 60
 ready_timeout: 60
 
 command_timeout: 180

--- a/config/ci/rsmp_gem.yaml
+++ b/config/ci/rsmp_gem.yaml
@@ -32,6 +32,7 @@ supervisor:
   status_update_timeout: 1
 
 connect_timeout: 1
+disconnect_timeout: 1
 ready_timeout: 1
 status_update_rate: 0   # rsmp only allow integer update rates
 subscribe_timeout: 1

--- a/config/ci/swarco_itc2.yaml
+++ b/config/ci/swarco_itc2.yaml
@@ -29,6 +29,7 @@ supervisor:
   status_update_timeout: 20
 
 connect_timeout: 120
+disconnect_timeout: 120
 ready_timeout: 10
 
 command_timeout: 180

--- a/spec/site/command_spec.rb
+++ b/spec/site/command_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'RSMP site commands' do
       prepare task, site
       #if ask_user site, "Going to restart controller. Press enter when ready or 's' to skip:"
       set_restart
-      expect { site.wait_for_state :stopped, RSMP_CONFIG['shutdown_timeout'] }.to_not raise_error
+      site.wait_for_state :stopped, RSMP_CONFIG['shutdown_timeout']
     end
     # NOTE
     # when a remote site closes the connection, our site proxy object will stop.
@@ -53,7 +53,7 @@ RSpec.describe 'RSMP site commands' do
     # it also means we need a new TestSite.
     TestSite.isolated do |task,supervisor,site|
       prepare task, site
-      expect { site.wait_for_state :ready, RSMP_CONFIG['ready_timeout'] }.to_not raise_error
+      site.wait_for_state :ready, RSMP_CONFIG['ready_timeout']
       wait_normal_control
     end
   end

--- a/spec/site/disconnect_spec.rb
+++ b/spec/site/disconnect_spec.rb
@@ -1,18 +1,18 @@
 # Test how the site responds to various incorrect behaviour.
 #
 # The site object passed by TestSite a SiteProxy object. We can redefine methods
-# on this object to modify behaviour after connection is established
+# on this object to modify behaviour after the connection has been established.
 #
 # Note that we use TestSite.isolate, rather than TestSite.connect,
-# to ensure we get a fresh SiteProxy object each time, and that it's not reused in
-# later tests
+# to ensure we get a fresh SiteProxy object each time, so our deformed site proxy
+# is not reused later tests
 
 RSpec.describe "RSMP site disconnect" do
   it 'disconnects if watchdogs are not acknowledged', sxl: '>=1.0.7' do |example|
     TestSite.isolated do |task,supervisor,site|
       def site.acknowledge original
       end
-      #expect { site.wait_for_state :stopping, 60 }.to_not raise_error
+      site.wait_for_state :stopped, RSMP_CONFIG['disconnect_timeout']
     end
   end
 
@@ -20,7 +20,7 @@ RSpec.describe "RSMP site disconnect" do
     TestSite.isolated do |task,supervisor,site|
       def site.send_watchdog now=nil
       end
-      #expect { site.wait_for_state :stopping, 180 }.to_not raise_error
+      site.wait_for_state :stopped, RSMP_CONFIG['disconnect_timeout']
     end
   end
 


### PR DESCRIPTION
Removes unnecessary use of expect {..}.not_to raise_error. The error can just propagate to rspec.

Also reactivates the two tests in  disconnect_spec.rb