### PR TITLE
ITC2 ci: Switch to TLC config made for testing purposes

### DIFF
--- a/config/ci/swarco_itc2.yaml
+++ b/config/ci/swarco_itc2.yaml
@@ -6,8 +6,9 @@ supervisor:
         - 3.1.2
       sxl_version: 1.0.7
       plans:
-        - 8
-        - 9
+        - 1
+        - 2
+        - 3
       traffic_situations: []
       emergency_routes:
         - 1

--- a/config/ci/swarco_itc2.yaml
+++ b/config/ci/swarco_itc2.yaml
@@ -6,8 +6,9 @@ supervisor:
         - 3.1.2
       sxl_version: 1.0.7
       plans:
+        - 1
+        - 7
         - 8
-        - 9
       traffic_situations: []
       emergency_routes:
         - 1

--- a/config/ci/swarco_itc2.yaml
+++ b/config/ci/swarco_itc2.yaml
@@ -6,9 +6,8 @@ supervisor:
         - 3.1.2
       sxl_version: 1.0.7
       plans:
-        - 1
-        - 7
         - 8
+        - 9
       traffic_situations: []
       emergency_routes:
         - 1


### PR DESCRIPTION
Test switching to a TLC config made for the automatic tests

- [x] Check time plans
- Check traffic situations - no such test case yet.
- Test configuration error - test case needs to be written first
- Test dead lock error (in swedish: väntetidsfel) - test case needs to be written first