### PR TITLE
ITC3 ci: First try to add ITC-3 for continous integration

### DIFF
--- a/.github/workflows/swarco_itc3.yml
+++ b/.github/workflows/swarco_itc3.yml
@@ -1,0 +1,48 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will run rspec
+
+name: Swarco ITC-3
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: [ self-hosted, Windows, X64, itc3 ]
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Configure test
+      run: |
+        "rsmp_config_path: config/ci/swarco_itc3.yaml" | Out-File 'config/validator.yaml' -Encoding utf8
+    - name: Set up secrets
+      run: |
+        "security_codes:`n    1: ''`n    2: ''" | Out-File 'config/secrets.yaml' -Encoding utf8
+    - name: Set up ruby
+      uses: ruby/setup-ruby@v1
+      env:
+        ImageOS: win19
+      with:
+        ruby-version: 3.0
+        bundler-cache: true # runs 'bundle install' and caches installed gems
+    - name: Run tests
+      run: bundle exec rspec spec/site
+    - name: Rename validation.log
+      if: always()
+      run: |
+        $date=Get-Date -Format 'yyyy-MM-dd_HH-mm'
+        mv log/validation.log log/validation_itc3_$date.log
+    - name: Upload validation.log
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: rspec validation
+        path: log/validation_itc3_*.log

--- a/config/swarco_itc3.yaml
+++ b/config/swarco_itc3.yaml
@@ -1,0 +1,40 @@
+port: 12111
+sxl: tlc
+intervals:
+  timer: 1
+  watchdog: 60
+timeouts:
+  watchdog: 120
+  acknowledgement: 20
+  connect: 120
+  ready: 60
+  status_response: 60
+  status_update: 60
+  subscribe: 60
+  command: 180
+  command_response: 180
+  alarm: 60
+  disconnect: 120
+  shutdown: 180
+components:
+  main:
+    KK+AG9998=001TC000:
+  signal_group:
+    KK+AG9998=001SG001:
+  detector_logic:
+    KK+AG9998=001DL001:
+items:
+  plans: [1,2,3]
+  traffic_situations: []
+  emergency_routes: [1]
+  inputs: [1]
+scripts:
+  activate_alarm: '/home/i0davla/activate_alarm.sh'
+  deactivate_alarm: '/home/i0davla/deactivate_alarm.sh'
+secrets:
+  security_codes:
+    1: ''
+    2: ''
+restrict_testing:
+  core_version: 3.1.2
+  sxl_version: 1.0.7 


### PR DESCRIPTION
- [x] Connect ITC-3 to Github Actions
- [x] Find the missing ITC-3
- [ ] Update the ITC-3 firmware to fix alarm issue with aSp, aS (should be fixed with next release)
- [x] Upload the traffic program (use the same as ITC-2)
- [ ] Adjust the ITC-3 configuration to allow testing of alarms
- [ ] Add activate/deactivate alarm scripts. The scripts from ITC2 can be reused. However, they need access to the terminal interface which is available on serial connection (RS232) in a real controller or TCP/IP in the simulator. We need to figure out which method we can use