### PR TITLE
support testing different rsmp core/sxl versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'd144a72', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '23bca01', :submodules => true
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '08789e8', :submodules => true
+gem 'rsmp', :submodules => true
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'd6094e6', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '08789e8', :submodules => true
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => '23bca01', :submodules => true
+gem 'rsmp', :github => 'rsmp-nordic/rsmp', :ref => 'd6094e6', :submodules => true
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: d6094e69f903e7f460aedb5c40765b58e1fa4a26
-  ref: d6094e6
-  submodules: true
-  specs:
-    rsmp (0.1.27)
-      async (~> 1.28.7)
-      async-io (~> 1.30.2)
-      colorize (~> 0.8.1)
-      rsmp_schemer (~> 0.2.0)
-      thor (~> 1.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -45,6 +32,12 @@ GEM
     minitest (5.14.3)
     nio4r (2.5.7)
     regexp_parser (2.1.1)
+    rsmp (0.1.27)
+      async (~> 1.28.7)
+      async-io (~> 1.30.2)
+      colorize (~> 0.8.1)
+      rsmp_schemer (~> 0.2.0)
+      thor (~> 1.0.1)
     rsmp_schemer (0.2.0)
       json_schemer (~> 0.2.18)
     rspec (3.10.0)
@@ -73,7 +66,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  rsmp!
+  rsmp
   rspec
   yard
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: d144a72e364de774cf10bb0d02237d53620f8b63
-  ref: d144a72
+  revision: 23bca01d6c4d68ca1d9935f33f39ce86f789b06f
+  ref: 23bca01
   submodules: true
   specs:
     rsmp (0.1.26)
       async (~> 1.28.7)
       async-io (~> 1.30.2)
       colorize (~> 0.8.1)
-      json_schemer (~> 0.2.18)
+      rsmp_schemer (~> 0.2.0)
       thor (~> 1.0.1)
 
 GEM
@@ -28,7 +28,7 @@ GEM
       async (~> 1.14)
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
-    console (1.10.1)
+    console (1.12.0)
       fiber-local
     diff-lcs (1.4.4)
     ecma-re-validator (0.3.0)
@@ -45,6 +45,8 @@ GEM
     minitest (5.14.3)
     nio4r (2.5.7)
     regexp_parser (2.1.1)
+    rsmp_schemer (0.2.0)
+      json_schemer (~> 0.2.18)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/rsmp-nordic/rsmp.git
-  revision: 23bca01d6c4d68ca1d9935f33f39ce86f789b06f
-  ref: 23bca01
+  revision: d6094e69f903e7f460aedb5c40765b58e1fa4a26
+  ref: d6094e6
   submodules: true
   specs:
-    rsmp (0.1.26)
+    rsmp (0.1.27)
       async (~> 1.28.7)
       async-io (~> 1.30.2)
       colorize (~> 0.8.1)

--- a/config/ci/rsmp_gem.yaml
+++ b/config/ci/rsmp_gem.yaml
@@ -2,6 +2,7 @@ supervisor:
   port: 13111
   sites:
     :any:
+      sxl: tlc
       rsmp_versions:
         - 3.1.5
       plans:

--- a/spec/site/signal_plans_spec.rb
+++ b/spec/site/signal_plans_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Traffic Light Controller" do
     # 3. Expect status response before timeout
     it 'S0097 version of traffic program', sxl: '>=1.0.15' do |example|
       request_status_and_confirm "version of traffic program",
-        { S0097: [:version,:hash] }
+        { S0097: [:timestamp,:checksum] }
     end
 
     # Verify that we change time plan (signal program)

--- a/spec/site/unknown_status_spec.rb
+++ b/spec/site/unknown_status_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "Traffic Light Controller" do
         status_list = convert_status_list( S0000:[:status] )
         site.request_status MAIN_COMPONENT, status_list, collect: {
           timeout: SUPERVISOR_CONFIG['command_response_timeout']
-        }
+        },
+        validate: false
       }.to raise_error(RSMP::MessageRejected)
     end
   end
@@ -20,7 +21,8 @@ RSpec.describe "Traffic Light Controller" do
         status_list = convert_status_list( S0001:[:bad] )
         site.request_status MAIN_COMPONENT, status_list, collect: {
           timeout: SUPERVISOR_CONFIG['command_response_timeout']
-        }
+        },
+        validate: false
       }.to raise_error(RSMP::MessageRejected)
     end
   end


### PR DESCRIPTION
The new gem 'rsmp_schemer' handles validating different version of the core/sxl json schema.

Todo:
handle behavioural differences between core versions
