### PR TITLE
Yellow flash

### DIFF
--- a/spec/site/tlc/yellow_flash.rb
+++ b/spec/site/tlc/yellow_flash.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Traffic Light Controller" do
+  include StatusHelpers
+  include CommandHelpers
+
+  describe "Yellow Flash" do
+
+    it 'M0001 set yellow flash', sxl: '>=1.0.7' do |example|
+      Validator::Site.connected do |task,supervisor,site|
+        prepare task, site
+
+        timeout =  10
+
+        switch_yellow_flash
+        wait_for_groups 'c', timeout: timeout      # c mean s yellow flash
+
+        switch_normal_control
+        wait_for_groups '[^c]', timeout: timeout   # not c, ie. not yellow flash
+      end
+    end
+
+  end
+end
+

--- a/spec/support/status_helpers.rb
+++ b/spec/support/status_helpers.rb
@@ -48,7 +48,9 @@ module StatusHelpers
     end
   end
 
-  def wait_for_status parent_task, description, status_list, update_rate: Validator.config['intervals']['status_update']
+  def wait_for_status parent_task, description, status_list,
+      update_rate: Validator.config['intervals']['status_update'],
+      timeout: Validator.config['timeouts']['command']
     update_rate = 0 unless update_rate
     log_confirmation description do
       subscribe_list = convert_status_list(status_list).map { |item| item.merge 'uRt'=>update_rate.to_s }
@@ -61,6 +63,17 @@ module StatusHelpers
         @site.unsubscribe_to_status Validator.config['main_component'], unsubscribe_list
       end
     end
+  end
+
+  def wait_for_groups state, timeout:
+    timeout = 10
+    regex = /^#{state}+$/
+    wait_for_status(@task,
+      "Wait for all groups to go to yellow flash",
+      [{'sCI'=>'S0001','n'=>'signalgroupstatus','s'=>regex}],
+      update_rate: 0,
+      timeout: timeout
+    )
   end
 
   def request_status_and_confirm description, status_list, component=Validator.config['main_component']


### PR DESCRIPTION
Demonstrates how to write a test that uses S0001 to check that groups go to a specific state.

In this case, we check that all groups go to 'c', which means yellow flash.
Afterwards we check we turn off yellow flash and check that groups are NOT 'c'.

