### PR TITLE
Run ITC-2 vm in a clean working environment

### DIFF
--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -36,6 +36,7 @@ jobs:
       if: always()
       run: mv log/validation.log log/validation_itc2_$(date +%F_%H-%M-%S).log
     - name: Stop ITC-2 simulator
+      if: always()
       run: virsh shutdown ts1001
     - name: Upload validation.log
       if: always()

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -26,6 +26,8 @@ jobs:
       run: bundle install
     - name: Start ITC-2 simulator
       run: virsh -c qemu:///system start ts1001
+    - name: Wait for ITC-2 simulator to start
+      run: sleep 30s
     - name: Set the time of the controller
       run: ssh 192.168.103.205 /home/i0davla/set_date.sh
     - name: Run tests

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Start ITC-2 simulator
       run: virsh -c qemu:///system start ts1001
     - name: Set the time of the controller
-      run: /home/i0davla/set_date.sh
+      run: ssh 192.168.103.205 /home/i0davla/set_date.sh
     - name: Run tests
       run: bundle exec rspec spec/site
       env:

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -24,6 +24,8 @@ jobs:
       run: bundle config set path '~/rsmp_gems/bundle'
     - name: Run bundle install
       run: bundle install
+    - name: Start ITC-2 simulator
+      run: virsh start ts1001
     - name: Set the time of the controller
       run: /home/i0davla/set_date.sh
     - name: Run tests
@@ -33,6 +35,8 @@ jobs:
     - name: Rename validation.log
       if: always()
       run: mv log/validation.log log/validation_itc2_$(date +%F_%H-%M-%S).log
+    - name: Stop ITC-2 simulator
+      run: virsh shutdown ts1001
     - name: Upload validation.log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -39,7 +39,7 @@ jobs:
       run: mv log/validation.log log/validation_itc2_$(date +%F_%H-%M-%S).log
     - name: Stop ITC-2 simulator
       if: always()
-      run: virsh shutdown ts1001
+      run: virsh -c qemu:///system shutdown ts1001
     - name: Upload validation.log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Run bundle install
       run: bundle install
     - name: Start ITC-2 simulator
-      run: virsh start ts1001
+      run: virsh -c qemu:///system start ts1001
     - name: Set the time of the controller
       run: /home/i0davla/set_date.sh
     - name: Run tests

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Wait for ITC-2 simulator to start
       run: sleep 30s
     - name: Set the time of the controller
-      run: ssh 192.168.103.205 /home/i0davla/set_date.sh
+      run: ssh 192.168.103.205 ./set_date.sh
     - name: Run tests
       run: bundle exec rspec spec/site
       env:
@@ -46,6 +46,9 @@ jobs:
       with:
         name: rspec validation
         path: log/validation_itc2_*.log
+    - name: Fetch itc2 rsmp log
+      if: always()
+      run: scp 192.168.103.205:/tmp/simulator.log /tmp/simulator.log
     - name: Upload itc2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Rename validation.log
       if: always()
       run: mv log/validation.log log/validation_itc2_$(date +%F_%H-%M-%S).log
+    - name: Fetch itc2 rsmp log
+      if: always()
+      run: scp 192.168.103.205:/tmp/simulator.log /tmp/simulator.log
     - name: Stop ITC-2 simulator
       if: always()
       run: virsh -c qemu:///system shutdown ts1001
@@ -46,9 +49,6 @@ jobs:
       with:
         name: rspec validation
         path: log/validation_itc2_*.log
-    - name: Fetch itc2 rsmp log
-      if: always()
-      run: scp 192.168.103.205:/tmp/simulator.log /tmp/simulator.log
     - name: Upload itc2 rsmp log
       if: always()
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
In order to minimize the risk of letting the previous run affect future runs, don't run the TLC continuously.  Start the TLC vm each run and shutdown the vm when done.

- [x] Move the Github runner to the hypervisor instead
- [x] Make sure the hypervisor can run ruby correctly
- [x] Start the TLC vm
- [x] Tune any timeouts (it takes a minute or two to start the vm)
- [x] Set the time correctly
- [x] Make sure the TLC vm connects to the hypervisor
- [x] Make sure log files are fetched correctly
- [x] Stop the TLC vm

