### PR TITLE
custom formatter that shows RSMP log messages

### DIFF
--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -32,7 +32,7 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
       run: bundle exec rspec --format Brief --format Details --out log/validation.log spec/site
-    - name: Show validation.log
+    - name: Show detailed log
       if: always()
       run: cat log/validation.log
     - name: Rename validation.log

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -32,6 +32,9 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
       run: bundle exec rspec spec/site
+    - name: Show validation.log
+      if: always()
+      run: cat log/validation.log
     - name: Rename validation.log
       if: always()
       run: |

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -31,7 +31,7 @@ jobs:
         ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
-      run: bundle exec rspec --format documentation --format Details --out log/validation.log spec/site
+      run: bundle exec rspec --format Brief --format Details --out log/validation.log spec/site
     - name: Show validation.log
       if: always()
       run: cat log/validation.log

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -31,7 +31,11 @@ jobs:
         ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
-      run: bundle exec rspec spec/site
+      run: |
+        bundle exec rspec \
+        --format documentation \
+        --format Details --out log/validation.log \
+        spec/site
     - name: Show validation.log
       if: always()
       run: cat log/validation.log

--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -31,11 +31,7 @@ jobs:
         ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems
     - name: Run tests
-      run: |
-        bundle exec rspec \
-        --format documentation \
-        --format Details --out log/validation.log \
-        spec/site
+      run: bundle exec rspec --format documentation --format Details --out log/validation.log spec/site
     - name: Show validation.log
       if: always()
       run: cat log/validation.log

--- a/.github/workflows/gem_supervisor.yml
+++ b/.github/workflows/gem_supervisor.yml
@@ -31,6 +31,9 @@ jobs:
       run: bundle exec rspec --tag '~script' spec/supervisor
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
+    - name: Show validation.log
+      if: always()
+      run: cat log/validation.log
     - name: Rename validation.log
       if: always()
       run: mv log/validation.log log/validation_ruby_$(date +%F_%H-%M-%S).log

--- a/.github/workflows/gem_supervisor.yml
+++ b/.github/workflows/gem_supervisor.yml
@@ -31,7 +31,7 @@ jobs:
       run: bundle exec rspec --format Brief --format Details --out log/validation.log --tag '~script' spec/supervisor
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
-    - name: Show validation.log
+    - name: Show detailed log
       if: always()
       run: cat log/validation.log
     - name: Rename validation.log

--- a/.github/workflows/gem_supervisor.yml
+++ b/.github/workflows/gem_supervisor.yml
@@ -28,7 +28,7 @@ jobs:
       run: bundle exec rsmp supervisor --config config/simulator/supervisor.yaml 2>&1 > simulator.log &
     - name: Run tests
       shell: bash
-      run: bundle exec rspec --format documentation --format Details --out log/validation.log --tag '~script' spec/supervisor
+      run: bundle exec rspec --format Brief --format Details --out log/validation.log --tag '~script' spec/supervisor
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
     - name: Show validation.log

--- a/.github/workflows/gem_supervisor.yml
+++ b/.github/workflows/gem_supervisor.yml
@@ -28,11 +28,7 @@ jobs:
       run: bundle exec rsmp supervisor --config config/simulator/supervisor.yaml 2>&1 > simulator.log &
     - name: Run tests
       shell: bash
-      run: |
-        bundle exec rspec \
-        --format documentation \
-        --format Details --out log/validation.log \
-        spec/supervisor
+      run: bundle exec rspec --format documentation --format Details --out log/validation.log --tag '~script' spec/supervisor
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
     - name: Show validation.log

--- a/.github/workflows/gem_supervisor.yml
+++ b/.github/workflows/gem_supervisor.yml
@@ -28,7 +28,11 @@ jobs:
       run: bundle exec rsmp supervisor --config config/simulator/supervisor.yaml 2>&1 > simulator.log &
     - name: Run tests
       shell: bash
-      run: bundle exec rspec --tag '~script' spec/supervisor
+      run: |
+        bundle exec rspec \
+        --format documentation \
+        --format Details --out log/validation.log \
+        spec/supervisor
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
     - name: Show validation.log

--- a/.github/workflows/gem_tlc.yml
+++ b/.github/workflows/gem_tlc.yml
@@ -31,7 +31,7 @@ jobs:
       run: bundle exec rspec --format Brief --format Details --out log/validation.log --tag '~script' spec/site
       env:
         SITE_CONFIG: config/gem_tlc.yaml
-    - name: Show validation.log
+    - name: Show detailed log
       if: always()
       run: cat log/validation.log
     - name: Rename validation.log

--- a/.github/workflows/gem_tlc.yml
+++ b/.github/workflows/gem_tlc.yml
@@ -28,12 +28,7 @@ jobs:
       run: bundle exec rsmp site --type tlc --config config/simulator/tlc.yaml 2>&1 > simulator.log &
     - name: Run tests
       shell: bash
-      run: |
-        bundle exec rspec \
-        --tag '~script' \
-        --format documentation \
-        --format Details --out log/validation.log \
-        spec/site
+      run: bundle exec rspec --format documentation --format Details --out log/validation.log --tag '~script' spec/site
       env:
         SITE_CONFIG: config/gem_tlc.yaml
     - name: Show validation.log

--- a/.github/workflows/gem_tlc.yml
+++ b/.github/workflows/gem_tlc.yml
@@ -28,7 +28,12 @@ jobs:
       run: bundle exec rsmp site --type tlc --config config/simulator/tlc.yaml 2>&1 > simulator.log &
     - name: Run tests
       shell: bash
-      run: bundle exec rspec --tag '~script' spec/site
+      run: |
+        bundle exec rspec \
+        --tag '~script' \
+        --format documentation \
+        --format Details --out log/validation.log \
+        spec/site
       env:
         SITE_CONFIG: config/gem_tlc.yaml
     - name: Show validation.log

--- a/.github/workflows/gem_tlc.yml
+++ b/.github/workflows/gem_tlc.yml
@@ -31,6 +31,9 @@ jobs:
       run: bundle exec rspec --tag '~script' spec/site
       env:
         SITE_CONFIG: config/gem_tlc.yaml
+    - name: Show validation.log
+      if: always()
+      run: cat log/validation.log
     - name: Rename validation.log
       if: always()
       run: mv log/validation.log log/validation_ruby_$(date +%F_%H-%M-%S).log

--- a/.github/workflows/gem_tlc.yml
+++ b/.github/workflows/gem_tlc.yml
@@ -28,7 +28,7 @@ jobs:
       run: bundle exec rsmp site --type tlc --config config/simulator/tlc.yaml 2>&1 > simulator.log &
     - name: Run tests
       shell: bash
-      run: bundle exec rspec --format documentation --format Details --out log/validation.log --tag '~script' spec/site
+      run: bundle exec rspec --format Brief --format Details --out log/validation.log --tag '~script' spec/site
       env:
         SITE_CONFIG: config/gem_tlc.yaml
     - name: Show validation.log

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -34,6 +34,9 @@ jobs:
       run: bundle exec rspec spec/site
       env:
         SITE_CONFIG: config/swarco_itc2.yaml
+    - name: Show validation.log
+      if: always()
+      run: cat log/validation.log
     - name: Rename validation.log
       if: always()
       run: mv log/validation.log log/validation_itc2_$(date +%F_%H-%M-%S).log

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set the time of the controller
       run: ssh 192.168.103.205 ./set_date.sh
     - name: Run tests
-      run: bundle exec rspec --format documentation --format Details --out log/validation.log spec/site
+      run: bundle exec rspec --format Brief --format Details --out log/validation.log spec/site
       env:
         SITE_CONFIG: config/swarco_itc2.yaml
     - name: Show validation.log

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -34,7 +34,7 @@ jobs:
       run: bundle exec rspec --format Brief --format Details --out log/validation.log spec/site
       env:
         SITE_CONFIG: config/swarco_itc2.yaml
-    - name: Show validation.log
+    - name: Show detailed log
       if: always()
       run: cat log/validation.log
     - name: Rename validation.log

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -31,12 +31,7 @@ jobs:
     - name: Set the time of the controller
       run: ssh 192.168.103.205 ./set_date.sh
     - name: Run tests
-      run: |
-        bundle exec rspec \
-        --format documentation \
-        --format Details --out log/validation.log \
-        spec/site
-
+      run: bundle exec rspec --format documentation --format Details --out log/validation.log spec/site
       env:
         SITE_CONFIG: config/swarco_itc2.yaml
     - name: Show validation.log

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -31,7 +31,12 @@ jobs:
     - name: Set the time of the controller
       run: ssh 192.168.103.205 ./set_date.sh
     - name: Run tests
-      run: bundle exec rspec spec/site
+      run: |
+        bundle exec rspec \
+        --format documentation \
+        --format Details --out log/validation.log \
+        spec/site
+
       env:
         SITE_CONFIG: config/swarco_itc2.yaml
     - name: Show validation.log

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper --force-color
+--format Details

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper --force-color
---format Details
+--format documentation
+--format Details --out log/validation.log

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
 --require spec_helper --force-color
---format documentation
---format Details --out log/validation.log

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.2)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    async (1.28.9)
+    async (1.29.1)
       console (~> 1.10)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-io (1.30.2)
+    async-io (1.32.1)
       async (~> 1.14)
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
@@ -32,9 +32,9 @@ GEM
     minitest (5.14.4)
     nio4r (2.5.7)
     regexp_parser (2.1.1)
-    rsmp (0.1.40)
-      async (~> 1.28.7)
-      async-io (~> 1.30.2)
+    rsmp (0.2.1)
+      async (~> 1.29.1)
+      async-io (~> 1.32.1)
       colorize (~> 0.8.1)
       rsmp_schemer
       thor (~> 1.0.1)
@@ -62,7 +62,6 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x64-mingw32
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -72,4 +71,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.15
+   2.2.21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x64-mingw32
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     minitest (5.14.4)
     nio4r (2.5.7)
     regexp_parser (2.1.1)
-    rsmp (0.1.39)
+    rsmp (0.1.40)
       async (~> 1.28.7)
       async-io (~> 1.30.2)
       colorize (~> 0.8.1)

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -37,6 +37,3 @@ secrets:
   security_codes:
     1: '1111'
     2: '2222'
-restrict_testing:
-  core_version: 3.1.2
-  sxl_version: 1.0.7 

--- a/guides/reporting.md
+++ b/guides/reporting.md
@@ -1,16 +1,49 @@
 # Reporting
 
-## RSpec Output
-When you run tests, RSpec will produce a report about what tests succeeded/fail. The output is printed to the console, but you can redirect it to a file if you want.
+## RSpec Output Formats
+When you run tests, RSpec will produce a report about what tests succeeded/fail. RSpec has several build-in report formats, including `progress`, `documentation`, `html` and `json`.
+
+The build-in formats are all useful, but the RSMP Validator comes with two additional formatters: `Brief` and `Details`.
+
+The `Brief` format is similar to the build in `documentation`, and show one line per test, colored according to the test result. However failing test show the error that occured.
+
+The `Details` format show a more detailed log of the steps each tests perform as well as all RSMP messages exchanged.
+
+You choose the output format usign the `--format` switch (or shorthand `-d`). The output is printed to the console be default:
 
 ```sh
-% bundle exec rspec spec/site > rspec.txt
+% bundle exec rspec spec/site --format Brief
 ```
 
-## Validation Log
-The validator produces a log detailing the progress of each tests. This log is located in `log/validation.log`.
+## Sentinel warnings
+Sometimes invalid messsage are received that are not direcly related to the currently executing test. For example, alarms or statuses can be received at any time. If such messages do not conform to the RSMP JSON schema, a sentinal will record the errors. Both the `Brief` and `Details` formatters will show sentinel warnings at the final summary. The `Details` formatter will also show the errors as they occur.
 
-You can inspect it after a test run, or use a `tail` in a second separate termiman to view the progress as tests are ongoing:
+## Multiple output formats
+Rspec allows you to select several output formats, and direct each one to the console or to a separate file. For example, you can show the brief format in the console, and direct the detailed log to a file using:
+
+```sh
+% bundle exec rspec spec/site --format Brief --format Details --out log/validation.log
+```
+
+## Default output outputs
+You can set default options for rspec by adding them to the file `.rspec-local`. For example, if you want to show the brief format in the console by default, while directing the detailed log to a file using:
+
+``sh
+% cat .rspec-local
+--format Brief
+--format Details --out log/validation.log
+``
+
+Now when you run rspec, the output formats will be used automaticallly and you can just run:
+
+``sh
+% bundle exec rspec
+``
+
+You can always override options in `.rspec-local` using options on the command-line.
+
+# Following logs during testing
+In case you direct a formatter to a file, you can use the `tail` command in a separate termimal window to view the progress as tests are running:
 
 ```sh
 % tail -f log/validation.log
@@ -26,6 +59,5 @@ The recommended way to document the result of a test run is to collect the follo
 - Validator config for the equipment tested
 - Version of the equipment, including relavant OS, software and hardware
 - Configuration in the equiqment
-- RSpec output
-- Validator log at log/validator.log
+- RSpec output in `Brief` and `Details` format.
 - Log file(s) from the equipment

--- a/guides/reporting.md
+++ b/guides/reporting.md
@@ -3,42 +3,61 @@
 ## RSpec Output Formats
 When you run tests, RSpec will produce a report about what tests succeeded/fail. RSpec has several build-in report formats, including `progress`, `documentation`, `html` and `json`.
 
-The build-in formats are all useful, but the RSMP Validator comes with two additional formatters: `Brief` and `Details`.
+The build-in formats are all useful, but the RSMP Validator comes with two additional formatters, `Brief` and `Details`, that shows additional RSMP-related information.
 
+## Brief format
 The `Brief` format is similar to the build in `documentation`, and show one line per test, colored according to the test result. However failing test show the error that occured.
 
-The `Details` format show a more detailed log of the steps each tests perform as well as all RSMP messages exchanged.
+```
+Traffic Light Controller
+  Clock
+    can be read with S0096
+    can be set with M0104
+    adjusts S0096 status response - Failed: Clock reported by S0096 is off by 24261830s, expected it to be within 2s
+    adjusts timestamps of S0096 command response - Failed: Timestamp of S0096 is off by 24261831s, expected it to be within 2s
+```
 
+# Detailed format
+The `Details` format show a more detailed log of the steps each test performs  as well as all RSMP messages exchanged.
+
+```
+Traffic Light Controller / Clock / can be read with S0096
+    2021-07-07T13:08:49.347Z                              Starting supervisor on port 13111
+> Waiting for site to connect
+    2021-07-07T13:08:49.410Z 53786                        Site connected from 127.0.0.1:53786
+    2021-07-07T13:08:49.427Z 53786    RN+SI0001     5087  Received Version message for site RN+SI0001 {"mType":"rSMsg","type":"Version","RSMP":[{"vers":"3.1.1"},{"vers":"3.1.2"},{"vers":"3.1.3"},{"vers":"3.1.4"},{"vers":"3.1.5"}],"siteId":[{"sId":"RN+SI0001"}],"SXL":"1.0.15","mId":"50871bcb-57c2-430d-ab0f-49077823d0ac"}
+    2021-07-07T13:08:49.457Z 53786    RN+SI0001           Sent MessageAck for Version 5087 {"mType":"rSMsg","type":"MessageAck","oMId":"50871bcb-57c2-430d-ab0f-49077823d0ac"}
+```
+
+
+## Choosing output formats
 You choose the output format usign the `--format` switch (or shorthand `-d`). The output is printed to the console be default:
 
 ```sh
 % bundle exec rspec spec/site --format Brief
 ```
 
-## Sentinel warnings
-Sometimes invalid messsage are received that are not direcly related to the currently executing test. For example, alarms or statuses can be received at any time. If such messages do not conform to the RSMP JSON schema, a sentinal will record the errors. Both the `Brief` and `Details` formatters will show sentinel warnings at the final summary. The `Details` formatter will also show the errors as they occur.
-
-## Multiple output formats
-Rspec allows you to select several output formats, and direct each one to the console or to a separate file. For example, you can show the brief format in the console, and direct the detailed log to a file using:
+##  Multiple outputs
+RSpec allows you to select several output formats, and direct each one to the console or to a separate file as you like. For example, you can show the brief format in the console, and direct the detailed log to a file using:
 
 ```sh
 % bundle exec rspec spec/site --format Brief --format Details --out log/validation.log
 ```
 
 ## Default output outputs
-You can set default options for rspec by adding them to the file `.rspec-local`. For example, if you want to show the brief format in the console by default, while directing the detailed log to a file using:
+You can set default options for the rspec command by adding them to the file `.rspec-local`. For example, if you want to show the brief format in the console by default, while directing the detailed log to a file::
 
-``sh
+```sh
 % cat .rspec-local
 --format Brief
 --format Details --out log/validation.log
-``
+```
 
 Now when you run rspec, the output formats will be used automaticallly and you can just run:
 
-``sh
+```sh
 % bundle exec rspec
-``
+```
 
 You can always override options in `.rspec-local` using options on the command-line.
 
@@ -48,6 +67,13 @@ In case you direct a formatter to a file, you can use the `tail` command in a se
 ```sh
 % tail -f log/validation.log
 ```
+
+## Sentinel Warnings
+Sometimes invalid messsage are received that are not direcly related to the currently executing test. For example, alarms or statuses can be received at any time. If such messages do not conform to the RSMP JSON schema, a sentinal warning will be recorded.
+
+Both the `Brief` and `Details` formatters will show sentinel warnings as part of the summary.
+
+The `Details` formatter will also show sentinel errors as they occur.
 
 ## Equipment Log
 Typically, the equipment you test also produces one or more internal log files. In case tests fail, it's often useful to have access to these these log files.

--- a/guides/reporting.md
+++ b/guides/reporting.md
@@ -1,12 +1,13 @@
 # Reporting
 
 ## RSpec Output Formats
-When you run tests, RSpec will produce a report about what tests succeeded/fail. RSpec has several build-in report formats, including `progress`, `documentation`, `html` and `json`.
+When you run tests, RSpec will report the results.
+RSpec has several build-in report formats, including `progress`, `documentation`, `html` and `json`. RSMP Validator comes with two additional formats, called `Brief` and `Details`.
 
-The build-in formats are all useful, but the RSMP Validator comes with two additional formatters, `Brief` and `Details`, that shows additional RSMP-related information.
+See the [RSpec docs](https://relishapp.com/rspec/rspec-core/v/2-6/docs/command-line/format-option) for more info about formatters.
 
 ## Brief format
-The `Brief` format is similar to the build in `documentation`, and show one line per test, colored according to the test result. However failing test show the error that occured.
+The `Brief` format is similar to the build-in `documentation` format. It show one line per test, colored according to the test result. But unlike `documentation`, it will include a bit of information about each failing tests directly in the progress overview:
 
 ```
 Traffic Light Controller
@@ -18,7 +19,7 @@ Traffic Light Controller
 ```
 
 # Detailed format
-The `Details` format show a more detailed log of the steps each test performs  as well as all RSMP messages exchanged.
+The `Details` format show a more detailed log of the steps each test performs  as well as all RSMP messages exchanged, with timestamp, port number, etc.
 
 ```
 Traffic Light Controller / Clock / can be read with S0096
@@ -29,22 +30,49 @@ Traffic Light Controller / Clock / can be read with S0096
     2021-07-07T13:08:49.457Z 53786    RN+SI0001           Sent MessageAck for Version 5087 {"mType":"rSMsg","type":"MessageAck","oMId":"50871bcb-57c2-430d-ab0f-49077823d0ac"}
 ```
 
+## Sentinel Warnings
+Sometimes invalid messsage are received that are not direcly related to the currently executing test. For example, alarms or statuses can be received at any time. If such messages do not conform to the RSMP JSON schema, a sentinal warning will be recorded.
+
+The `Brief` and `Details` formats will show sentinel warnings in the summary:
+
+```
+Sentinel warnings:
+
+   1) RSMP::SchemaError
+
+      Received invalid Alarm, schema errors: /aSp, enum, , /aS, enum, , /cat, enum, {"mType":"rSMsg","type":"Alarm","mId":"4b844bfd-330e-4d3f-ab69-80417c8d1fbb","ntsOId":"KK+AG9998=001TC000","xNId":"","cId":"KK+AG9998=001SG004","aCId":"A0202","xACId":"C_LAMP_L1_RED (60, 4, 26) : Signal Group #4","xNACId":"","aSp":"issue","ack":"notAcknowledged","aS":"active","sS":"notSuspended","aTs":"2021-07-07T12:30:25.000Z","cat":"b","pri":"3","rvs":[{"n":"color","v":"red"}]}
+```
+
+
+The `Details` formatter will also show sentinel errors as they occur, as part of the datail message log:
+
+```
+    2021-07-07T12:30:59.290Z 43286    KK+AG9998=001TC000 4b84  Received invalid Alarm, schema errors: /aSp, enum, , /aS, enum, , /cat, enum, {"mType":"rSMsg","type":"Alarm","mId":"4b844bfd-330e-4d3f-ab69-80417c8d1fbb","ntsOId":"KK+AG9998=001TC000","xNId":"","cId":"KK+AG9998=001SG004","aCId":"A0202","xACId":"C_LAMP_L1_RED (60, 4, 26) : Signal Group #4","xNACId":"","aSp":"issue","ack":"notAcknowledged","aS":"active","sS":"notSuspended","aTs":"2021-07-07T12:30:25.000Z","cat":"b","pri":"3","rvs":[{"n":"color","v":"red"}]}
+```
 
 ## Choosing output formats
-You choose the output format usign the `--format` switch (or shorthand `-d`). The output is printed to the console be default:
+You choose the output format with the `--format` switch (or shorthand `-d`) of the `rspec` command.
 
 ```sh
 % bundle exec rspec spec/site --format Brief
 ```
 
+By default, the output is printed to the console, but you can redirect it to a file:
+
+```sh
+% bundle exec rspec spec/site --format Brief --out log/brief.log
+```
+
 ##  Multiple outputs
-RSpec allows you to select several output formats, and direct each one to the console or to a separate file as you like. For example, you can show the brief format in the console, and direct the detailed log to a file using:
+RSpec allows you to select several output formats, and direct each one to a separate file. A formatter that's not directed to a file will print to the terminal.
+
+For example, you can show the brief format in the console, and also direct the detailed log to a file with:
 
 ```sh
 % bundle exec rspec spec/site --format Brief --format Details --out log/validation.log
 ```
 
-## Default output outputs
+## Default output formats
 You can set default options for the rspec command by adding them to the file `.rspec-local`. For example, if you want to show the brief format in the console by default, while directing the detailed log to a file::
 
 ```sh
@@ -67,13 +95,6 @@ In case you direct a formatter to a file, you can use the `tail` command in a se
 ```sh
 % tail -f log/validation.log
 ```
-
-## Sentinel Warnings
-Sometimes invalid messsage are received that are not direcly related to the currently executing test. For example, alarms or statuses can be received at any time. If such messages do not conform to the RSMP JSON schema, a sentinal warning will be recorded.
-
-Both the `Brief` and `Details` formatters will show sentinel warnings as part of the summary.
-
-The `Details` formatter will also show sentinel errors as they occur.
 
 ## Equipment Log
 Typically, the equipment you test also produces one or more internal log files. In case tests fail, it's often useful to have access to these these log files.

--- a/spec/site/core/aggregated_status_spec.rb
+++ b/spec/site/core/aggregated_status_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe 'Core' do
             timeout: Validator.config['timeouts']['status_response']
           }
         end
+        expect {
+          raise "bad"
+        }.not_to raise_error
       end
     end
   end

--- a/spec/site/core/aggregated_status_spec.rb
+++ b/spec/site/core/aggregated_status_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe 'Core' do
             timeout: Validator.config['timeouts']['status_response']
           }
         end
-        expect {
-          raise "bad"
-        }.not_to raise_error
       end
     end
   end

--- a/spec/site/core/aggregated_status_spec.rb
+++ b/spec/site/core/aggregated_status_spec.rb
@@ -1,7 +1,7 @@
-RSpec.describe "Traffic Light Controller" do
+RSpec.describe 'Core' do
   include CommandHelpers
 
-  describe "Aggregated Status" do
+  describe 'Aggregated Status' do
     # Verify that the controller responds to an aggregated status request.
     #
     # 1. Given the site is connected

--- a/spec/site/core/connect_spec.rb
+++ b/spec/site/core/connect_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Core' do
       got_watchdog_messages = got[4..7]
 
       expect(got_version_messages).to include(*expected_version_messages)
-      expect(expected_watchdog_messages).to include(*got_watchdog_messages)
+      expect(got_watchdog_messages).to include(*expected_watchdog_messages)
     end
 
     def check_sequence_3_1_4 version

--- a/spec/site/core/connect_spec.rb
+++ b/spec/site/core/connect_spec.rb
@@ -1,126 +1,127 @@
-RSpec.describe "Traffic Light Controller" do
-
-  def get_connection_message core_version, length
-    timeout = Validator.config['timeouts']['ready']
-    got = nil
-    Validator::Site.isolated(
-      'rsmp_versions' => [core_version],
-      'collect' => length
-    ) do |task,supervisor,site|
-      site.collector.collect task, timeout: timeout
-      expect(site.ready?).to be true
-      got = site.collector.messages.map { |message| [message.direction.to_s, message.type] }
+RSpec.describe 'Core' do
+  describe 'Connection Sequence' do
+    def get_connection_message core_version, length
+      timeout = Validator.config['timeouts']['ready']
+      got = nil
+      Validator::Site.isolated(
+        'rsmp_versions' => [core_version],
+        'collect' => length
+      ) do |task,supervisor,site|
+        site.collector.collect task, timeout: timeout
+        expect(site.ready?).to be true
+        got = site.collector.messages.map { |message| [message.direction.to_s, message.type] }
+      end
+      got
+    rescue Async::TimeoutError => e
+      raise "Did not collect #{length} messages within #{timeout}s"
     end
-    got
-  rescue Async::TimeoutError => e
-    raise "Did not collect #{length} messages within #{timeout}s"
-  end
 
-  def check_sequence_3_1_1 core_version
-    # in earlier core version, both sides sends a Version
-    # message simulatenously. we therefore cannot expect
-    # a specific sequence
-    # but we can expect a set of messages
+    def check_sequence_3_1_1 core_version
+      # in earlier core version, both sides sends a Version
+      # message simulatenously. we therefore cannot expect
+      # a specific sequence
+      # but we can expect a set of messages
 
-    expected_version_messages = [
-      ['in','Version'],
-      ['out','MessageAck'],
-      ['out','Version'],
-      ['in','MessageAck'],
-    ]
-    expected_watchdog_messages = [
-      ['in','Watchdog'],
-      ['out','MessageAck'],
-      ['out','Watchdog'],
-      ['in','MessageAck']
-    ]
+      expected_version_messages = [
+        ['in','Version'],
+        ['out','MessageAck'],
+        ['out','Version'],
+        ['in','MessageAck'],
+      ]
+      expected_watchdog_messages = [
+        ['in','Watchdog'],
+        ['out','MessageAck'],
+        ['out','Watchdog'],
+        ['in','MessageAck']
+      ]
 
-    length = expected_version_messages.length +
-             expected_watchdog_messages.length
+      length = expected_version_messages.length +
+               expected_watchdog_messages.length
 
-    got = get_connection_message core_version, length
-    got_version_messages = got[0..3]
-    got_watchdog_messages = got[4..7]
+      got = get_connection_message core_version, length
+      got_version_messages = got[0..3]
+      got_watchdog_messages = got[4..7]
 
-    expect(got_version_messages).to include(*expected_version_messages)
-    expect(expected_watchdog_messages).to include(*got_watchdog_messages)
-  end
-
-  def check_sequence_3_1_4 version
-    expected = [
-      ['in','Version'],
-      ['out','MessageAck'],
-      ['out','Version'],
-      ['in','MessageAck'],
-      ['in','Watchdog'],
-      ['out','MessageAck'],
-      ['out','Watchdog'],
-      ['in','MessageAck'],
-      ['in','AggregatedStatus'],
-      ['out','MessageAck']
-    ]
-    got = get_connection_message version, expected.length
-    expect(got).to eq(expected)
-  end
-
-  def check_sequence version
-    case version
-    when '3.1.1', '3.1.2', '3.1.3'
-      check_sequence_3_1_1 version
-    when '3.1.4', '3.1.5'
-      check_sequence_3_1_4 version
-    else
-      raise "Unkown rsmp version #{version}"
+      expect(got_version_messages).to include(*expected_version_messages)
+      expect(expected_watchdog_messages).to include(*got_watchdog_messages)
     end
-  end
 
-  # Verify the connection sequence when using rsmp core 3.1.1
-  #
-  # 1. Given the site is connected and using core 3.1.1
-  # 2. When handshake messages are sent and received
-  # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.1
-  # 4. And the connection sequence should be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.1', rsmp: '3.1.1' do |example|
-    check_sequence '3.1.1'
-  end
+    def check_sequence_3_1_4 version
+      expected = [
+        ['in','Version'],
+        ['out','MessageAck'],
+        ['out','Version'],
+        ['in','MessageAck'],
+        ['in','Watchdog'],
+        ['out','MessageAck'],
+        ['out','Watchdog'],
+        ['in','MessageAck'],
+        ['in','AggregatedStatus'],
+        ['out','MessageAck']
+      ]
+      got = get_connection_message version, expected.length
+      expect(got).to eq(expected)
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.2
-  #
-  # 1. Given the site is connected and using core 3.1.2
-  # 2. When handshake messages are sent and received
-  # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.2
-  # 4. And the connection sequence should be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.2', rsmp: '3.1.2' do |example|
-    check_sequence '3.1.2'
-  end
+    def check_sequence version
+      case version
+      when '3.1.1', '3.1.2', '3.1.3'
+        check_sequence_3_1_1 version
+      when '3.1.4', '3.1.5'
+        check_sequence_3_1_4 version
+      else
+        raise "Unkown rsmp version #{version}"
+      end
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.3
-  #
-  # 1. Given the site is connected and using core 3.1.3
-  # 2. When handshake messages are sent and received
-  # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.3
-  # 4. And the connection sequence should be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.3', rsmp: '3.1.3' do |example|
-    check_sequence '3.1.3'
-  end
+    # Verify the connection sequence when using rsmp core 3.1.1
+    #
+    # 1. Given the site is connected and using core 3.1.1
+    # 2. When handshake messages are sent and received
+    # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.1
+    # 4. And the connection sequence should be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.1', rsmp: '3.1.1' do |example|
+      check_sequence '3.1.1'
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.4
-  #
-  # 1. Given the site is connected and using core 3.1.4
-  # 2. When handshake messages are sent and received
-  # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.4
-  # 4. And the connection sequence should be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.4', rsmp: '3.1.4' do |example|
-    check_sequence '3.1.4'
-  end
+    # Verify the connection sequence when using rsmp core 3.1.2
+    #
+    # 1. Given the site is connected and using core 3.1.2
+    # 2. When handshake messages are sent and received
+    # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.2
+    # 4. And the connection sequence should be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.2', rsmp: '3.1.2' do |example|
+      check_sequence '3.1.2'
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.5
-  #
-  # 1. Given the site is connected and using core 3.1.5
-  # 2. When handshake messages are sent and received
-  # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.5
-  # 4. And the connection sequence should be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.5', rsmp: '3.1.5' do |example|
-    check_sequence '3.1.5'
+    # Verify the connection sequence when using rsmp core 3.1.3
+    #
+    # 1. Given the site is connected and using core 3.1.3
+    # 2. When handshake messages are sent and received
+    # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.3
+    # 4. And the connection sequence should be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.3', rsmp: '3.1.3' do |example|
+      check_sequence '3.1.3'
+    end
+
+    # Verify the connection sequence when using rsmp core 3.1.4
+    #
+    # 1. Given the site is connected and using core 3.1.4
+    # 2. When handshake messages are sent and received
+    # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.4
+    # 4. And the connection sequence should be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.4', rsmp: '3.1.4' do |example|
+      check_sequence '3.1.4'
+    end
+
+    # Verify the connection sequence when using rsmp core 3.1.5
+    #
+    # 1. Given the site is connected and using core 3.1.5
+    # 2. When handshake messages are sent and received
+    # 3. Then the handshake messages should be in the specified sequence corresponding to version 3.1.5
+    # 4. And the connection sequence should be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.5', rsmp: '3.1.5' do |example|
+      check_sequence '3.1.5'
+    end
   end
 end

--- a/spec/site/core/disconnect_spec.rb
+++ b/spec/site/core/disconnect_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe 'Core' do
       Validator::Site.isolated do |task,supervisor,site|
         def site.acknowledge original
         end
-        site.wait_for_state :stopped, Validator.config['timeouts']['disconnect']
+        timeout = Validator.config['timeouts']['disconnect']
+        site.wait_for_state :stopped, timeout
+      rescue RSMP::TimeoutError
+        raise "Site did not disconnect within #{timeout}s"
       end
     end
 
@@ -29,7 +32,10 @@ RSpec.describe 'Core' do
       Validator::Site.isolated do |task,supervisor,site|
         def site.send_watchdog now=nil
         end
-        site.wait_for_state :stopped, Validator.config['timeouts']['disconnect']
+        timeout = Validator.config['timeouts']['disconnect']
+        site.wait_for_state :stopped, timeout
+      rescue RSMP::TimeoutError
+        raise "Site did not disconnect within #{timeout}s"
       end
     end
   end

--- a/spec/site/core/disconnect_spec.rb
+++ b/spec/site/core/disconnect_spec.rb
@@ -7,28 +7,30 @@
 # to ensure we get a fresh SiteProxy object each time, so our deformed site proxy
 # is not reused later tests
 
-RSpec.describe "Traffic Light Controller" do
+RSpec.describe 'Core' do
 
-  # 1. Given the site is new and connected
-  # 2. When site watchdog acknowledgement method is changed to do nothing
-  # 3. Then the site should disconnect
-  it 'disconnects if watchdogs are not acknowledged', sxl: '>=1.0.7' do |example|
-    Validator::Site.isolated do |task,supervisor,site|
-      def site.acknowledge original
+  describe 'Disconnect Behaviour' do
+
+    # 1. Given the site is new and connected
+    # 2. When site watchdog acknowledgement method is changed to do nothing
+    # 3. Then the site should disconnect
+    it 'disconnects if watchdogs are not acknowledged', sxl: '>=1.0.7' do |example|
+      Validator::Site.isolated do |task,supervisor,site|
+        def site.acknowledge original
+        end
+        site.wait_for_state :stopped, Validator.config['timeouts']['disconnect']
       end
-      site.wait_for_state :stopped, Validator.config['timeouts']['disconnect']
+    end
+
+    # 1. Given the site is new and connected
+    # 2. When site watchdog sending method is changed to do nothing
+    # 3. Then the supervisor should disconnect
+    it 'disconnects if no watchdogs are send', sxl: '>=1.0.7' do |example|
+      Validator::Site.isolated do |task,supervisor,site|
+        def site.send_watchdog now=nil
+        end
+        site.wait_for_state :stopped, Validator.config['timeouts']['disconnect']
+      end
     end
   end
-
-  # 1. Given the site is new and connected
-  # 2. When site watchdog sending method is changed to do nothing
-  # 3. Then the supervisor should disconnect
-  it 'disconnects if no watchdogs are send', sxl: '>=1.0.7' do |example|
-    Validator::Site.isolated do |task,supervisor,site|
-      def site.send_watchdog now=nil
-      end
-      site.wait_for_state :stopped, Validator.config['timeouts']['disconnect']
-    end
-  end
-
 end

--- a/spec/site/tlc/alarm_spec.rb
+++ b/spec/site/tlc/alarm_spec.rb
@@ -2,100 +2,102 @@ RSpec.describe 'Traffic Light Controller' do
   include CommandHelpers
   include StatusHelpers
 
-  it 'A0302 detector error (logic error)', :script, sxl: '>=1.0.7' do |example|
-    require_scripts
-    Validator::Site.connected do |task,supervisor,site|
-      component = Validator.config['components']['detector_logic'].keys.first
-      system(Validator.config['scripts']['activate_alarm'])
-      site.log "Waiting for alarm", level: :test
-      start_time = Time.now
-      message, response = nil,nil
-      expect do
-        response = site.wait_for_alarm task, component: component, aCId: 'A0302',
-          aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
-      end.to_not raise_error, "Did not receive alarm"
-
-      delay = Time.now - start_time
-      site.log "alarm confirmed after #{delay.to_i}s", level: :test
-      system(Validator.config['scripts']['deactivate_alarm'])
-
-      alarm_time = Time.parse(response[:message].attributes["aTs"])
-      expect(alarm_time).to be_within(1.minute).of Time.now.utc
-      expect(response[:message].attributes['rvs']).to eq([{
-        "n":"detector","v":"1"},
-        {"n":"type","v":"loop"},
-        {"n":"errormode","v":"on"},
-        {"n":"manual","v":"True"},
-        {"n":"logicerror","v":"always_off"}
-      ])
-    ensure
-      system(Validator.config['scripts']['deactivate_alarm'])
-    end
-  end
-
-  it 'Acknowledge alarm', :script do |example|
-    skip "Don't yet have a way to trigger alarms on the equipment"
-    require_scripts
-    Validator::Site.connected do |task,supervisor,site|
-      component = Validator.config['components']['detector_logic'].keys.first
-      system(Validator.config['scripts']['activate_alarm'])
-      site.log "Waiting for alarm", level: :test
-      start_time = Time.now
-      message, response = nil,nil
-      expect do
-        response = site.wait_for_alarm task, component: component, aCId: 'A0302',
-          aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
-      end.to_not raise_error, "Did not receive alarm"
-  
-      alarm_code_id = 'A0302'
-      message = site.send_alarm_acknowledgement Validator.config['main_component'], alarm_code_id
-  
-      delay = Time.now - start_time
-      site.log "alarm confirmed after #{delay.to_i}s", level: :test
-      
-      expect do
-        response = @site.wait_for_alarm_acknowledged_response message: message, component: Validator.config['main_component'], timeout: Validator.config['timeouts']['alarm']
-      end.to_not raise_error
-      
-      expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
-      expect(response).to be_a(RSMP::AlarmAcknowledgedResponse)
-      expect(response.attributes['cId']).to eq(Validator.config['main_component'])
-    ensure 
-      system(Validator.config['scripts']['deactivate_alarm'])
-    end
-  end
-
-  it 'buffers alarms during disconnects', :script, sxl: '>=1.0.7' do |example|
-    require_scripts
-    component = Validator.config['components']['detector_logic'].keys.first
-    Validator::Site.isolated do |task,supervisor,site|
-    end      
-    # Activate alarm 
-    system(Validator.config['scripts']['activate_alarm'])
-
-    Validator::Site.isolated do |task,supervisor,site|
-      site = site
-      log_confirmation "Waiting for alarm" do
+  describe 'Alarms' do
+    it 'A0302 detector error (logic error)', :script, sxl: '>=1.0.7' do |example|
+      require_scripts
+      Validator::Site.connected do |task,supervisor,site|
+        component = Validator.config['components']['detector_logic'].keys.first
+        system(Validator.config['scripts']['activate_alarm'])
+        site.log "Waiting for alarm", level: :test
+        start_time = Time.now
         message, response = nil,nil
         expect do
           response = site.wait_for_alarm task, component: component, aCId: 'A0302',
             aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
         end.to_not raise_error, "Did not receive alarm"
 
-      end
-      system(Validator.config['scripts']['deactivate_alarm'])
+        delay = Time.now - start_time
+        site.log "alarm confirmed after #{delay.to_i}s", level: :test
+        system(Validator.config['scripts']['deactivate_alarm'])
 
-      alarm_time = Time.parse(response[:message].attributes["aTs"])
-      expect(alarm_time).to be_within(1.minute).of Time.now.utc
-      expect(response[:message].attributes['rvs']).to eq([{
-        "n":"detector","v":"1"},
-        {"n":"type","v":"loop"},
-        {"n":"errormode","v":"on"},
-        {"n":"manual","v":"True"},
-        {"n":"logicerror","v":"always_off"}
-      ])
-    ensure
-      system(Validator.config['scripts']['deactivate_alarm'])
+        alarm_time = Time.parse(response[:message].attributes["aTs"])
+        expect(alarm_time).to be_within(1.minute).of Time.now.utc
+        expect(response[:message].attributes['rvs']).to eq([{
+          "n":"detector","v":"1"},
+          {"n":"type","v":"loop"},
+          {"n":"errormode","v":"on"},
+          {"n":"manual","v":"True"},
+          {"n":"logicerror","v":"always_off"}
+        ])
+      ensure
+        system(Validator.config['scripts']['deactivate_alarm'])
+      end
+    end
+
+    it 'Acknowledge alarm', :script do |example|
+      skip "Don't yet have a way to trigger alarms on the equipment"
+      require_scripts
+      Validator::Site.connected do |task,supervisor,site|
+        component = Validator.config['components']['detector_logic'].keys.first
+        system(Validator.config['scripts']['activate_alarm'])
+        site.log "Waiting for alarm", level: :test
+        start_time = Time.now
+        message, response = nil,nil
+        expect do
+          response = site.wait_for_alarm task, component: component, aCId: 'A0302',
+            aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
+        end.to_not raise_error, "Did not receive alarm"
+
+        alarm_code_id = 'A0302'
+        message = site.send_alarm_acknowledgement Validator.config['main_component'], alarm_code_id
+
+        delay = Time.now - start_time
+        site.log "alarm confirmed after #{delay.to_i}s", level: :test
+
+        expect do
+          response = @site.wait_for_alarm_acknowledged_response message: message, component: Validator.config['main_component'], timeout: Validator.config['timeouts']['alarm']
+        end.to_not raise_error
+
+        expect(response).not_to be_a(RSMP::MessageNotAck), "Message rejected: #{response.attributes['rea']}"
+        expect(response).to be_a(RSMP::AlarmAcknowledgedResponse)
+        expect(response.attributes['cId']).to eq(Validator.config['main_component'])
+      ensure 
+        system(Validator.config['scripts']['deactivate_alarm'])
+      end
+    end
+
+    it 'buffers alarms during disconnects', :script, sxl: '>=1.0.7' do |example|
+      require_scripts
+      component = Validator.config['components']['detector_logic'].keys.first
+      Validator::Site.isolated do |task,supervisor,site|
+      end
+      # Activate alarm
+      system(Validator.config['scripts']['activate_alarm'])
+
+      Validator::Site.isolated do |task,supervisor,site|
+        site = site
+        log_confirmation "Waiting for alarm" do
+          message, response = nil,nil
+          expect do
+            response = site.wait_for_alarm task, component: component, aCId: 'A0302',
+              aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
+          end.to_not raise_error, "Did not receive alarm"
+
+        end
+        system(Validator.config['scripts']['deactivate_alarm'])
+
+        alarm_time = Time.parse(response[:message].attributes["aTs"])
+        expect(alarm_time).to be_within(1.minute).of Time.now.utc
+        expect(response[:message].attributes['rvs']).to eq([{
+          "n":"detector","v":"1"},
+          {"n":"type","v":"loop"},
+          {"n":"errormode","v":"on"},
+          {"n":"manual","v":"True"},
+          {"n":"logicerror","v":"always_off"}
+        ])
+      ensure
+        system(Validator.config['scripts']['deactivate_alarm'])
+      end
     end
   end
 end

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "Traffic Light Controller" do
     # 4. Request aggregated status
     # 5. Compare set_clock and response timestamp
     # 6. Expect the difference to be within max_diff
-    it 'timestamps aggregated status response with adjusted clock', sxl: '>=1.0.7' do |example|
+    it 'timestamps aggregated status response with adjusted clock', core: '>=3.1.5', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Traffic Light Controller" do
             Validator.config['timeouts']['status_response']
 
           diff = received - CLOCK
-
+          diff = diff.round
           expect(diff.abs).to be <= max_diff, 
             "Clock reported by S0096 is off by #{diff}s, expected it to be within #{max_diff}s"
         end
@@ -109,7 +109,7 @@ RSpec.describe "Traffic Light Controller" do
           message = messages.first
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
           diff = Time.parse(message.attributes['sTs']) - CLOCK
-          
+          diff = diff.round          
           expect(diff.abs).to be <= max_diff,
             "Timestamp of S0096 is off by #{diff}s, expected it to be within #{max_diff}s"
         end
@@ -133,6 +133,7 @@ RSpec.describe "Traffic Light Controller" do
           }
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
           diff = Time.parse(response.attributes['aSTS']) - CLOCK
+          diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of aggregated status is off by #{diff}s, expected it to be within #{max_diff}s"
         end
@@ -154,6 +155,7 @@ RSpec.describe "Traffic Light Controller" do
           message = messages.first
           max_diff = Validator.config['timeouts']['command_response'] * 2
           diff = Time.parse(message.attributes['cTS']) - CLOCK
+          diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of command response is off by #{diff}s, expected it to be within #{max_diff}s"          
         end
@@ -175,6 +177,7 @@ RSpec.describe "Traffic Light Controller" do
           message = messages.first
           max_diff = Validator.config['timeouts']['command_response']
           diff = Time.parse(message.attributes['cTS']) - CLOCK
+          diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of command response is off by #{diff}s, expected it to be within #{max_diff}s"
         end
@@ -201,6 +204,7 @@ RSpec.describe "Traffic Light Controller" do
           response = site.wait_for_alarm task, timeout: Validator.config['timeouts']['alarm']
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
           diff = Time.parse(response.attributes['sTs']) - CLOCK
+          diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of alarm is off by #{diff}s, expected it to be within #{max_diff}s"
         end
@@ -222,6 +226,7 @@ RSpec.describe "Traffic Light Controller" do
           response = site.collect task, type: "Watchdog", num: 1, timeout: Validator.config['timeouts']['watchdog']
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
           diff = Time.parse(response.attributes['wTs']) - CLOCK
+          diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of watchdog is off by #{diff}s, expected it to be within #{max_diff}s"
         end

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Traffic Light Controller" do
   include StatusHelpers
   
   describe 'Clock' do
-    DATE = Time.new 2020,9,29,17,29,51,'UTC'
+    CLOCK = Time.new 2020,9,29,17,29,51,'UTC'
  
     # Verify status 0096 current date and time
     #
@@ -30,21 +30,21 @@ RSpec.describe "Traffic Light Controller" do
     it 'sets clock with M0104', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        set_date(DATE)
+        set_clock(CLOCK)
       end
     end
 
-    # Verify status S0096 date after changing date
+    # Verify status S0096 clock after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to set_date
+    # 2. Send control command to set_clock
     # 3. Request status S0096
-    # 4. Compare set_date and status timestamp
+    # 4. Compare set_clock and status timestamp
     # 5. Expect the difference to be within max_diff
     it 'reports adjusted clock in S0096', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
           status_list = { S0096: [
             :year,
             :month,
@@ -58,33 +58,39 @@ RSpec.describe "Traffic Light Controller" do
           }
           status = "S0096"
 
-          received = Time.new response[{"sCI" => status, "n" => "year"}]["s"],
-          response[{"sCI" => status, "n" => "month"}]["s"],
-          response[{"sCI" => status, "n" => "day"}]["s"],
-          response[{"sCI" => status, "n" => "hour"}]["s"],
-          response[{"sCI" => status, "n" => "minute"}]["s"],
-          response[{"sCI" => status, "n" => "second"}]["s"],
-          'UTC'
+          received = Time.new(
+            response[{"sCI" => status, "n" => "year"}]["s"],
+            response[{"sCI" => status, "n" => "month"}]["s"],
+            response[{"sCI" => status, "n" => "day"}]["s"],
+            response[{"sCI" => status, "n" => "hour"}]["s"],
+            response[{"sCI" => status, "n" => "minute"}]["s"],
+            response[{"sCI" => status, "n" => "second"}]["s"],
+            'UTC'
+          )
 
-          max_diff = Validator.config['timeouts']['command_response'] + 
-                    Validator.config['timeouts']['status_response']
-          diff = received - DATE
-          expect(diff.abs).to be <= max_diff
+          max_diff =
+            Validator.config['timeouts']['command_response'] + 
+            Validator.config['timeouts']['status_response']
+
+          diff = received - CLOCK
+
+          expect(diff.abs).to be <= max_diff, 
+            "Clock reported by S0096 is off by #{diff}s, expected it to be within #{max_diff}s"
         end
       end
     end
 
-    # Verify status response timestamp after changing date
+    # Verify status response timestamp after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to set_date
+    # 2. Send control command to set_clock
     # 3. Request status S0096
-    # 4. Compare set_date and response timestamp
+    # 4. Compare set_clock and response timestamp
     # 5. Expect the difference to be within max_diff
     it 'timestamps S0096 with adjusted clock', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
           status_list = { S0096: [
             :year,
             :month,
@@ -102,114 +108,122 @@ RSpec.describe "Traffic Light Controller" do
 
           message = messages.first
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-          diff = Time.parse(message.attributes['sTs']) - DATE
-          expect(diff.abs).to be <= max_diff
+          diff = Time.parse(message.attributes['sTs']) - CLOCK
+          
+          expect(diff.abs).to be <= max_diff,
+            "Timestamp of S0096 is off by #{diff}s, expected it to be within #{max_diff}s"
         end
       end
     end
 
-    # Verify aggregated status response timestamp after changing date
+    # Verify aggregated status response timestamp after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to set date
+    # 2. Send control command to set clock
     # 3. Wait for status = true
     # 4. Request aggregated status
-    # 5. Compare set_date and response timestamp
+    # 5. Compare set_clock and response timestamp
     # 6. Expect the difference to be within max_diff
     it 'timestamps aggregated status response with adjusted clock', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
           request, response = site.request_aggregated_status Validator.config['main_component'], collect: {
             timeout: Validator.config['timeouts']['status_response']
           }
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-          diff = Time.parse(response.attributes['aSTS']) - DATE
-          expect(diff.abs).to be <= max_diff
+          diff = Time.parse(response.attributes['aSTS']) - CLOCK
+          expect(diff.abs).to be <= max_diff,
+            "Timestamp of aggregated status is off by #{diff}s, expected it to be within #{max_diff}s"
         end
       end
     end
 
-    # Verify command response timestamp after changing date
+    # Verify command response timestamp after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to set date
+    # 2. Send control command to set clock
     # 3. Send command to set functional position
-    # 4. Compare set_date and response timestamp
+    # 4. Compare set_clock and response timestamp
     # 5. Expect the difference to be within max_diff
     it 'timestamps command response with adjusted clock', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
           request, response, messages = set_functional_position 'NormalControl'
           message = messages.first
           max_diff = Validator.config['timeouts']['command_response'] * 2
-          diff = Time.parse(message.attributes['cTS']) - DATE
-          expect(diff.abs).to be <= max_diff
+          diff = Time.parse(message.attributes['cTS']) - CLOCK
+          expect(diff.abs).to be <= max_diff,
+            "Timestamp of command response is off by #{diff}s, expected it to be within #{max_diff}s"          
         end
       end
     end
 
-    # Verify command response timestamp after changing date
+    # Verify command response timestamp after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to set date
+    # 2. Send control command to set clock
     # 3. Send command to set functional position
-    # 4. Compare set_date and response timestamp
+    # 4. Compare set_clock and response timestamp
     # 5. Expect the difference to be within max_diff
     it 'timestamps M0104 command response with adjusted clock', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
           request, response, messages = set_functional_position 'NormalControl'
           message = messages.first
           max_diff = Validator.config['timeouts']['command_response']
-          diff = Time.parse(message.attributes['cTS']) - DATE
-          expect(diff.abs).to be <= max_diff
+          diff = Time.parse(message.attributes['cTS']) - CLOCK
+          expect(diff.abs).to be <= max_diff,
+            "Timestamp of command response is off by #{diff}s, expected it to be within #{max_diff}s"
         end
       end
     end
 
-    # Verify timestamp of alarm after changing date
+    # Verify timestamp of alarm after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to set_date
+    # 2. Send control command to set_clock
     # 3. Wait for status = true
     # 4. Trigger alarm from Script
     # 5. Wait for alarm
-    # 6. Compare set_date and alarm response timestamp
+    # 6. Compare set_clock and alarm response timestamp
     # 7. Expect the difference to be within max_diff
     it 'timestamps alarm with adjusted clock', :script, sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         require_scripts
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
           component = Validator.config['components']['detector_logic'].keys.first
           system(Validator.config['scripts']['activate_alarm'])
           site.log "Waiting for alarm", level: :test
           response = site.wait_for_alarm task, timeout: Validator.config['timeouts']['alarm']
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-          diff = Time.parse(response.attributes['sTs']) - DATE
-          expect(diff.abs).to be <= max_diff
+          diff = Time.parse(response.attributes['sTs']) - CLOCK
+          expect(diff.abs).to be <= max_diff,
+            "Timestamp of alarm is off by #{diff}s, expected it to be within #{max_diff}s"
         end
       end
     end
 
-    # Verify timestamp of watchdog after changing date
+    # Verify timestamp of watchdog after changing clock
     #
     # 1. Given the site is connected
-    # 2. Send control command to setset_date
+    # 2. Send control command to setset_clock
     # 3. Wait for Watchdog
-    # 4. Compare set_date and alarm response timestamp
+    # 4. Compare set_clock and alarm response timestamp
     # 5. Expect the difference to be within max_diff
     it 'timestamps watchdog messages with adjusted clock', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_date_set DATE do
+        with_clock_set CLOCK do
+          Validator.log "Checking watchdog timestamp", level: :test
           response = site.collect task, type: "Watchdog", num: 1, timeout: Validator.config['timeouts']['watchdog']
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-          diff = Time.parse(response.attributes['wTs']) - DATE
-          expect(diff.abs).to be <= max_diff
+          diff = Time.parse(response.attributes['wTs']) - CLOCK
+          expect(diff.abs).to be <= max_diff,
+            "Timestamp of watchdog is off by #{diff}s, expected it to be within #{max_diff}s"
         end
       end
     end

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Traffic Light Controller" do
   include StatusHelpers
   
   describe 'Clock' do
-    CLOCK = Time.new 2020,9,29,17,29,51,'UTC'
+    CLOCK = Time.new 2020,9,29,17,29,51,'+00:00'
  
     # Verify status 0096 current date and time
     #

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Traffic Light Controller" do
     # 1. Given the site is connected
     # 2. Request status
     # 3. Expect status response before timeout
-    it 'S0096 current date and time', sxl: '>=1.0.7'  do |example|
+    it 'can be read with S0096', sxl: '>=1.0.7'  do |example|
       request_status_and_confirm "current date and time",
         { S0096: [
           :year,
@@ -27,7 +27,7 @@ RSpec.describe "Traffic Light Controller" do
     # 1. Given the site is connected
     # 2. Send command
     # 3. Expect status response before timeout
-    it 'sets clock with M0104', sxl: '>=1.0.7' do |example|
+    it 'can be set with M0104', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         set_clock(CLOCK)
@@ -41,7 +41,7 @@ RSpec.describe "Traffic Light Controller" do
     # 3. Request status S0096
     # 4. Compare set_clock and status timestamp
     # 5. Expect the difference to be within max_diff
-    it 'reports adjusted clock in S0096', sxl: '>=1.0.7' do |example|
+    it 'adjusts S0096 status response', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
@@ -87,7 +87,7 @@ RSpec.describe "Traffic Light Controller" do
     # 3. Request status S0096
     # 4. Compare set_clock and response timestamp
     # 5. Expect the difference to be within max_diff
-    it 'timestamps S0096 with adjusted clock', sxl: '>=1.0.7' do |example|
+    it 'adjusts timestamps of S0096 command response', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
@@ -124,7 +124,7 @@ RSpec.describe "Traffic Light Controller" do
     # 4. Request aggregated status
     # 5. Compare set_clock and response timestamp
     # 6. Expect the difference to be within max_diff
-    it 'timestamps aggregated status response with adjusted clock', core: '>=3.1.5', sxl: '>=1.0.7' do |example|
+    it 'adjusts timestamps of aggregated status response', core: '>=3.1.5', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
@@ -147,7 +147,7 @@ RSpec.describe "Traffic Light Controller" do
     # 3. Send command to set functional position
     # 4. Compare set_clock and response timestamp
     # 5. Expect the difference to be within max_diff
-    it 'timestamps command response with adjusted clock', sxl: '>=1.0.7' do |example|
+    it 'adjusts timestamps of command response', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
@@ -169,7 +169,7 @@ RSpec.describe "Traffic Light Controller" do
     # 3. Send command to set functional position
     # 4. Compare set_clock and response timestamp
     # 5. Expect the difference to be within max_diff
-    it 'timestamps M0104 command response with adjusted clock', sxl: '>=1.0.7' do |example|
+    it 'adjusts timestamps of M0104 command response', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
@@ -218,7 +218,7 @@ RSpec.describe "Traffic Light Controller" do
     # 3. Wait for Watchdog
     # 4. Compare set_clock and alarm response timestamp
     # 5. Expect the difference to be within max_diff
-    it 'timestamps watchdog messages with adjusted clock', sxl: '>=1.0.7' do |example|
+    it 'adjusts timestamp of watchdog messages', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do

--- a/spec/site/tlc/subscribe_spec.rb
+++ b/spec/site/tlc/subscribe_spec.rb
@@ -1,25 +1,26 @@
 RSpec.describe "Traffic Light Controller" do
-  
-  # Check that we can *subscribe* to status messages.
-  # The test subscribes to S0001 (signal group status), but
-  # this is arbitrary as we simply want to check that
-  # the subscription mechanism works.
-  #
-  # 1. subscribe
-  # 1. check that we receive a status update with a predefined time
-  # 1. unsubscribe
-  
-  it 'responds to valid status subscription' do |example|
-    Validator::Site.connected do |task,supervisor,site|
-      component = Validator.config['main_component']
-      status_list = [{'sCI'=>'S0001','n'=>'signalgroupstatus','uRt'=>'1' }]
-      site.subscribe_to_status component, status_list, collect: {
-        timeout: Validator.config['timeouts']['status_update']
-      }
-    ensure
-      unsubscribe_list = status_list.map { |item| item.slice('sCI','n') }
-      site.unsubscribe_to_status component, unsubscribe_list
+  describe 'Subscriptions' do
+
+    # Check that we can *subscribe* to status messages.
+    # The test subscribes to S0001 (signal group status), but
+    # this is arbitrary as we simply want to check that
+    # the subscription mechanism works.
+    #
+    # 1. subscribe
+    # 1. check that we receive a status update with a predefined time
+    # 1. unsubscribe
+
+    it 'responds to valid status subscription' do |example|
+      Validator::Site.connected do |task,supervisor,site|
+        component = Validator.config['main_component']
+        status_list = [{'sCI'=>'S0001','n'=>'signalgroupstatus','uRt'=>'1' }]
+        site.subscribe_to_status component, status_list, collect: {
+          timeout: Validator.config['timeouts']['status_update']
+        }
+      ensure
+        unsubscribe_list = status_list.map { |item| item.slice('sCI','n') }
+        site.unsubscribe_to_status component, unsubscribe_list
+      end
     end
   end
-
 end

--- a/spec/site/tlc/unknown_status_spec.rb
+++ b/spec/site/tlc/unknown_status_spec.rb
@@ -1,30 +1,31 @@
 RSpec.describe "Traffic Light Controller" do
   include StatusHelpers
 
-  it 'responds with NotAck to invalid status request code' do |example|
-    Validator::Site.connected do |task,supervisor,site|
-      site.log "Requesting non-existing status S0000", level: :test
-      expect {
-        status_list = convert_status_list( S0000:[:status] )
-        site.request_status Validator.config['main_component'], status_list, collect: {
-          timeout: Validator.config['timeouts']['command_response']
-        },
-        validate: false
-      }.to raise_error(RSMP::MessageRejected)
+  describe 'Unknown Statuses' do
+    it 'responds with NotAck to invalid status request code' do |example|
+      Validator::Site.connected do |task,supervisor,site|
+        site.log "Requesting non-existing status S0000", level: :test
+        expect {
+          status_list = convert_status_list( S0000:[:status] )
+          site.request_status Validator.config['main_component'], status_list, collect: {
+            timeout: Validator.config['timeouts']['command_response']
+          },
+          validate: false
+        }.to raise_error(RSMP::MessageRejected)
+      end
+    end
+
+    it 'responds with NotAck to invalid status request name' do |example|
+      Validator::Site.connected do |task,supervisor,site|
+        site.log "Requesting non-existing status S0001 name", level: :test
+        expect {
+          status_list = convert_status_list( S0001:[:bad] )
+          site.request_status Validator.config['main_component'], status_list, collect: {
+            timeout: Validator.config['timeouts']['command_response']
+          },
+          validate: false
+        }.to raise_error(RSMP::MessageRejected)
+      end
     end
   end
-
-  it 'responds with NotAck to invalid status request name' do |example|
-    Validator::Site.connected do |task,supervisor,site|
-      site.log "Requesting non-existing status S0001 name", level: :test
-      expect {
-        status_list = convert_status_list( S0001:[:bad] )
-        site.request_status Validator.config['main_component'], status_list, collect: {
-          timeout: Validator.config['timeouts']['command_response']
-        },
-        validate: false
-      }.to raise_error(RSMP::MessageRejected)
-    end
-  end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,13 +10,15 @@ require_relative 'support/command_helpers'
 require_relative 'support/status_helpers'
 require_relative 'support/log_helpers'
 require_relative 'support/secrets_helpers'
+require_relative 'support/formatter.rb'
 
 include RSpec
 include LogHelpers
 
-
 # configure RSpec
 RSpec.configure do |config|
+  
+  #config.reporter.message "configure"
   Validator.setup config
 
   # Enable flags like --only-failures and --next-failure
@@ -30,17 +32,18 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do |example|
-    log "Testing started at #{Time.now}".colorize(:light_black)
+    #example.reporter.message "before suite!"
+    #log "Testing started at #{Time.now}".colorize(:light_black)
   end
 
   # write to the validator log when each test start
   config.before(:example) do |example|
-    log "\nRunning test #{example.metadata[:location]} - #{example.full_description}".colorize(:light_black)
+    #log "\nRunning test #{example.metadata[:location]} - #{example.full_description}".colorize(:light_black)
   end
 
-  config.after(:suite) do
-    Validator.after
-    log "Testing ended at #{Time.now}\n".colorize(:light_black)
+  config.after(:suite) do |example|
+    Validator.after example
+    #example.reporter.message "Testing ended at #{Time.now}\n".colorize(:light_black)
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,9 @@ require_relative 'support/command_helpers'
 require_relative 'support/status_helpers'
 require_relative 'support/log_helpers'
 require_relative 'support/secrets_helpers'
-require_relative 'support/formatter.rb'
+require_relative 'support/formatters/report_stream.rb'
+require_relative 'support/formatters/brief.rb'
+require_relative 'support/formatters/details.rb'
 
 include RSpec
 include LogHelpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require_relative 'support/status_helpers'
 require_relative 'support/log_helpers'
 require_relative 'support/secrets_helpers'
 require_relative 'support/formatters/report_stream.rb'
+require_relative 'support/formatters/formatter_base.rb'
 require_relative 'support/formatters/brief.rb'
 require_relative 'support/formatters/details.rb'
 

--- a/spec/supervisor/aggregated_status_spec.rb
+++ b/spec/supervisor/aggregated_status_spec.rb
@@ -1,13 +1,15 @@
-RSpec.describe 'RSMP supervisor' do
-  it 'receives aggretated status' do
-    Validator::Supervisor.connected do |task,site,supervisor_proxy|
-      component = site.find_component Validator.config['main_component']
+RSpec.describe 'Supervisor' do
+  describe 'Aggregated Status' do
+    it 'receives aggregated status' do
+      Validator::Supervisor.connected do |task,site,supervisor_proxy|
+        component = site.find_component Validator.config['main_component']
 
-      # setting ':collect' will cause set_aggregated_status() to wait for the
-      # outgoing aggregated status is acknowledged
-      component.set_aggregated_status :high_priority_alarm, collect: {
-        timeout: Validator.config['timeouts']['acknowledgement']
-      }
+        # setting ':collect' will cause set_aggregated_status() to wait for the
+        # outgoing aggregated status is acknowledged
+        component.set_aggregated_status :high_priority_alarm, collect: {
+          timeout: Validator.config['timeouts']['acknowledgement']
+        }
+      end
     end
   end
 end

--- a/spec/supervisor/connect_spec.rb
+++ b/spec/supervisor/connect_spec.rb
@@ -1,125 +1,127 @@
-RSpec.describe "Supervisor" do
+RSpec.describe 'Supervisor' do
 
-  def get_connection_message core_version, length
-    got = nil
-    Validator::Supervisor.isolated(
-      'rsmp_versions' => [core_version],
-      'collect' => length
-    ) do |task,site,supervisor_proxy|
-      supervisor_proxy.collector.collect task, timeout: Validator.config['timeouts']['ready']
-      expect(supervisor_proxy.ready?).to be true
-      got = supervisor_proxy.collector.messages.map { |message| [message.direction.to_s, message.type] }
+  describe 'Connection Sequence' do
+    def get_connection_message core_version, length
+      got = nil
+      Validator::Supervisor.isolated(
+        'rsmp_versions' => [core_version],
+        'collect' => length
+      ) do |task,site,supervisor_proxy|
+        supervisor_proxy.collector.collect task, timeout: Validator.config['timeouts']['ready']
+        expect(supervisor_proxy.ready?).to be true
+        got = supervisor_proxy.collector.messages.map { |message| [message.direction.to_s, message.type] }
+      end
+      got
+    rescue Async::TimeoutError => e
+      raise "Did not collect #{length} messages within #{timeout}s"
     end
-    got
-  rescue Async::TimeoutError => e
-    raise "Did not collect #{length} messages within #{timeout}s"
-  end
 
-  def check_sequence_3_1_1 core_version
-    # in earlier core version, both sides sends a Version
-    # message simulatenously. we therefore cannot expect
-    # a specific sequence
-    # but we can expect a set of messages
+    def check_sequence_3_1_1 core_version
+      # in earlier core version, both sides sends a Version
+      # message simulatenously. we therefore cannot expect
+      # a specific sequence
+      # but we can expect a set of messages
 
-    expected_version_messages = [
-      ['out','Version'],
-      ['in','MessageAck'],
-      ['in','Version'],
-      ['out','MessageAck'],
-    ]
-    expected_watchdog_messages = [
-      ['out','Watchdog'],
-      ['in','MessageAck'],
-      ['in','Watchdog'],
-      ['out','MessageAck']
-    ]
+      expected_version_messages = [
+        ['out','Version'],
+        ['in','MessageAck'],
+        ['in','Version'],
+        ['out','MessageAck'],
+      ]
+      expected_watchdog_messages = [
+        ['out','Watchdog'],
+        ['in','MessageAck'],
+        ['in','Watchdog'],
+        ['out','MessageAck']
+      ]
 
-    length = expected_version_messages.length +
-             expected_watchdog_messages.length
+      length = expected_version_messages.length +
+               expected_watchdog_messages.length
 
-    got = get_connection_message core_version, length
-    got_version_messages = got[0..3]
-    got_watchdog_messages = got[4..7]
+      got = get_connection_message core_version, length
+      got_version_messages = got[0..3]
+      got_watchdog_messages = got[4..7]
 
-    expect(got_version_messages).to include(*expected_version_messages)
-    expect(expected_watchdog_messages).to include(*got_watchdog_messages)
-  end
-
-  def check_sequence_3_1_4 version
-    expected = [
-      ['out','Version'],
-      ['in','MessageAck'],
-      ['in','Version'],
-      ['out','MessageAck'],
-      ['out','Watchdog'],
-      ['in','MessageAck'],
-      ['in','Watchdog'],
-      ['out','MessageAck'],
-      ['out','AggregatedStatus'],
-      ['in','MessageAck']
-    ]
-    got = get_connection_message version, expected.length
-    expect(got).to eq(expected)
-  end
-
-  def check_sequence version
-    case version
-    when '3.1.1', '3.1.2', '3.1.3'
-      check_sequence_3_1_1 version
-    when '3.1.4', '3.1.5'
-      check_sequence_3_1_4 version
-    else
-      raise "Unkown rsmp version #{version}"
+      expect(got_version_messages).to include(*expected_version_messages)
+      expect(expected_watchdog_messages).to include(*got_watchdog_messages)
     end
-  end
 
-  # Verify the connection sequence when using rsmp core 3.1.1
-  #
-  # 1. Given the site is connected and using core 3.1.1
-  # 2. Send and receive handshake messages
-  # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.1
-  # 4. Expect the connection sequence to be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.1', rsmp: '3.1.1' do |example|
-    check_sequence '3.1.1'
-  end
+    def check_sequence_3_1_4 version
+      expected = [
+        ['out','Version'],
+        ['in','MessageAck'],
+        ['in','Version'],
+        ['out','MessageAck'],
+        ['out','Watchdog'],
+        ['in','MessageAck'],
+        ['in','Watchdog'],
+        ['out','MessageAck'],
+        ['out','AggregatedStatus'],
+        ['in','MessageAck']
+      ]
+      got = get_connection_message version, expected.length
+      expect(got).to eq(expected)
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.2
-  #
-  # 1. Given the site is connected and using core 3.1.2
-  # 2. Send and receive handshake messages
-  # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.2
-  # 4. Expect the connection sequence to be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.2', rsmp: '3.1.2' do |example|
-    check_sequence '3.1.2'
-  end
+    def check_sequence version
+      case version
+      when '3.1.1', '3.1.2', '3.1.3'
+        check_sequence_3_1_1 version
+      when '3.1.4', '3.1.5'
+        check_sequence_3_1_4 version
+      else
+        raise "Unkown rsmp version #{version}"
+      end
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.3
-  #
-  # 1. Given the site is connected and using core 3.1.3
-  # 2. Send and receive handshake messages
-  # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.3
-  # 4. Expect the connection sequence to be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.3', rsmp: '3.1.3' do |example|
-    check_sequence '3.1.3'
-  end
+    # Verify the connection sequence when using rsmp core 3.1.1
+    #
+    # 1. Given the site is connected and using core 3.1.1
+    # 2. Send and receive handshake messages
+    # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.1
+    # 4. Expect the connection sequence to be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.1', rsmp: '3.1.1' do |example|
+      check_sequence '3.1.1'
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.4
-  #
-  # 1. Given the site is connected and using core 3.1.4
-  # 2. Send and receive handshake messages
-  # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.4
-  # 4. Expect the connection sequence to be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.4', rsmp: '3.1.4' do |example|
-    check_sequence '3.1.4'
-  end
+    # Verify the connection sequence when using rsmp core 3.1.2
+    #
+    # 1. Given the site is connected and using core 3.1.2
+    # 2. Send and receive handshake messages
+    # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.2
+    # 4. Expect the connection sequence to be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.2', rsmp: '3.1.2' do |example|
+      check_sequence '3.1.2'
+    end
 
-  # Verify the connection sequence when using rsmp core 3.1.5
-  #
-  # 1. Given the site is connected and using core 3.1.5
-  # 2. Send and receive handshake messages
-  # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.5
-  # 4. Expect the connection sequence to be complete
-  it 'exchanges correct connection sequence of rsmp version 3.1.5', rsmp: '3.1.5' do |example|
-    check_sequence '3.1.5'
+    # Verify the connection sequence when using rsmp core 3.1.3
+    #
+    # 1. Given the site is connected and using core 3.1.3
+    # 2. Send and receive handshake messages
+    # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.3
+    # 4. Expect the connection sequence to be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.3', rsmp: '3.1.3' do |example|
+      check_sequence '3.1.3'
+    end
+
+    # Verify the connection sequence when using rsmp core 3.1.4
+    #
+    # 1. Given the site is connected and using core 3.1.4
+    # 2. Send and receive handshake messages
+    # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.4
+    # 4. Expect the connection sequence to be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.4', rsmp: '3.1.4' do |example|
+      check_sequence '3.1.4'
+    end
+
+    # Verify the connection sequence when using rsmp core 3.1.5
+    #
+    # 1. Given the site is connected and using core 3.1.5
+    # 2. Send and receive handshake messages
+    # 3. Expect the handshake messages to be in the specified sequence corresponding to version 3.1.5
+    # 4. Expect the connection sequence to be complete
+    it 'exchanges correct connection sequence of rsmp version 3.1.5', rsmp: '3.1.5' do |example|
+      check_sequence '3.1.5'
+    end
   end
 end

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -296,14 +296,14 @@ module CommandHelpers
 
   def require_security_codes
     unless Validator.config.dig 'secrets', 'security_codes' 
-      skip "Skipping test: Security codes are not configured"
+      skip "Security codes are not configured"
     end
   end
 
   def require_scripts
-    skip "Skipping test: Scripts are not configured" unless Validator.config['scripts']
-    skip "Skipping test: Script to activate alarm is not configured" unless Validator.config.dig 'scripts', 'activate_alarm'
-    skip "Skipping test: Script to deactivate alarm is not configured" unless Validator.config.dig 'scripts','deactivate_alarm'
+    skip "Scripts are not configured" unless Validator.config['scripts']
+    skip "Script to activate alarm is not configured" unless Validator.config.dig 'scripts', 'activate_alarm'
+    skip "Script to deactivate alarm is not configured" unless Validator.config.dig 'scripts','deactivate_alarm'
   end
 
   def set_clock clock

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -22,7 +22,7 @@ module CommandHelpers
 
   def set_signal_start status
     require_security_codes
-    @site.log "Start of signal group. Orders a signal group to green.", level: :test
+    Validator.log "Start of signal group. Orders a signal group to green.", level: :test
     command_list = build_command_list :M0010, :setStart, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -34,7 +34,7 @@ module CommandHelpers
 
   def set_signal_stop status
     require_security_codes
-    @site.log "Stop of signal group. Orders a signal group to red.", level: :test
+    Validator.log "Stop of signal group. Orders a signal group to red.", level: :test
     command_list = build_command_list :M0011, :setStop, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -45,7 +45,7 @@ module CommandHelpers
   end
 
   def set_signal_start_or_stop status
-    @site.log "Request start or stop of a series of signal groups", level: :test
+    Validator.log "Request start or stop of a series of signal groups", level: :test
     command_list = build_command_list :M0012, :setStart, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -56,7 +56,7 @@ module CommandHelpers
 
   def set_plan plan
     require_security_codes
-    @site.log "Switching to plan #{plan}", level: :test
+    Validator.log "Switching to plan #{plan}", level: :test
     command_list = build_command_list :M0002, :setPlan, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: 'True',     # true = use plan nr in commone, false = use time table
@@ -67,7 +67,7 @@ module CommandHelpers
 
   def set_traffic_situation ts
     require_security_codes
-    @site.log "Switching to traffic situation #{ts}", level: :test
+    Validator.log "Switching to traffic situation #{ts}", level: :test
     command_list = build_command_list :M0003, :setTrafficSituation, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       traficsituation: ts   # misspell 'traficsituation'is in the rsmp spec
@@ -78,7 +78,7 @@ module CommandHelpers
 
   def set_functional_position status
     require_security_codes
-    @site.log "Switching to #{status}", level: :test
+    Validator.log "Switching to #{status}", level: :test
     command_list = build_command_list :M0001, :setValue, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -90,7 +90,7 @@ module CommandHelpers
 
   def set_fixed_time status
     require_security_codes
-    @site.log "Switching to fixed time #{status}", level: :test
+    Validator.log "Switching to fixed time #{status}", level: :test
     command_list = build_command_list :M0007, :setFixedTime, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -100,7 +100,7 @@ module CommandHelpers
 
   def set_restart
     require_security_codes
-    @site.log "Restarting traffic controller", level: :test
+    Validator.log "Restarting traffic controller", level: :test
     command_list = build_command_list :M0004, :setRestart, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: 'True'
@@ -112,7 +112,7 @@ module CommandHelpers
 
   def set_emergency_route route
     require_security_codes
-    @site.log "Set emergency route #{route}", level: :test
+    Validator.log "Set emergency route #{route}", level: :test
     command_list = build_command_list :M0005, :setEmergency, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: 'True',
@@ -123,7 +123,7 @@ module CommandHelpers
 
   def disable_emergency_route
     require_security_codes
-    @site.log "Disable emergency route", level: :test
+    Validator.log "Disable emergency route", level: :test
     command_list = build_command_list :M0005, :setEmergency, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: 'False'
@@ -133,7 +133,7 @@ module CommandHelpers
 
   def set_input status, input
     require_security_codes
-    @site.log "Set input #{input}", level: :test
+    Validator.log "Set input #{input}", level: :test
     command_list = build_command_list :M0006, :setInput, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -144,7 +144,7 @@ module CommandHelpers
 
   def force_detector_logic component, status, mode='True'
     require_security_codes
-    @site.log "Force detector logic", level: :test
+    Validator.log "Force detector logic", level: :test
     command_list = build_command_list :M0008, :setForceDetectorLogic, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -187,7 +187,7 @@ module CommandHelpers
 
   def set_series_of_inputs status
     require_security_codes
-    @site.log "Activate a series of inputs", level: :test
+    Validator.log "Activate a series of inputs", level: :test
     command_list = build_command_list :M0013, :setInput, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -197,7 +197,7 @@ module CommandHelpers
 
   def set_dynamic_bands status, plan
     require_security_codes
-    @site.log "Set dynamic bands", level: :test
+    Validator.log "Set dynamic bands", level: :test
     command_list = build_command_list :M0014, :setCommands, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -208,7 +208,7 @@ module CommandHelpers
 
   def set_offset status, plan
     require_security_codes
-    @site.log "Set dynamic bands", level: :test
+    Validator.log "Set dynamic bands", level: :test
     command_list = build_command_list :M0015, :setOffset, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -219,7 +219,7 @@ module CommandHelpers
 
   def set_week_table status
     require_security_codes
-    @site.log "Set week table", level: :test
+    Validator.log "Set week table", level: :test
     command_list = build_command_list :M0016, :setWeekTable, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -229,7 +229,7 @@ module CommandHelpers
 
   def set_time_table status
     require_security_codes
-    @site.log "Set time table", level: :test
+    Validator.log "Set time table", level: :test
     command_list = build_command_list :M0017, :setTimeTable, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -239,7 +239,7 @@ module CommandHelpers
 
   def set_cycle_time status, plan
     require_security_codes
-    @site.log "Set cycle time", level: :test
+    Validator.log "Set cycle time", level: :test
     command_list = build_command_list :M0018, :setCycleTime, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -250,7 +250,7 @@ module CommandHelpers
 
   def force_input status, input, value
     require_security_codes
-    @site.log "Force input", level: :test
+    Validator.log "Force input", level: :test
     command_list = build_command_list :M0019, :setInput, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -262,7 +262,7 @@ module CommandHelpers
 
   def force_output status, output, value
     require_security_codes
-    @site.log "Force output", level: :test
+    Validator.log "Force output", level: :test
     command_list = build_command_list :M0020, :setOutput, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status,
@@ -274,7 +274,7 @@ module CommandHelpers
 
   def set_trigger_level status
     require_security_codes
-    @site.log "Set trigger level sensitivity for loop detector", level: :test
+    Validator.log "Set trigger level sensitivity for loop detector", level: :test
     command_list = build_command_list :M0021, :setLevel, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: status
@@ -285,7 +285,7 @@ module CommandHelpers
   def set_security_code level
     require_security_codes
     status = "Level#{level}"
-    @site.log "Set security code", level: :test
+    Validator.log "Set security code", level: :test
     command_list = build_command_list :M0103, :setSecurityCode, {
       oldSecurityCode: Validator.config['secrets']['security_codes'][level],
       newSecurityCode: Validator.config['secrets']['security_codes'][level],
@@ -306,24 +306,24 @@ module CommandHelpers
     skip "Skipping test: Script to deactivate alarm is not configured" unless Validator.config.dig 'scripts','deactivate_alarm'
   end
 
-  def set_date date
+  def set_clock clock
     require_security_codes
-    @site.log "Set date to #{date}", level: :test
+    Validator.log "Setting clock to #{clock}", level: :test
     command_list = build_command_list :M0104, :setDate, {
       securityCode: Validator.config['secrets']['security_codes'][1],
-      year: date.year,
-      month: date.month,
-      day: date.day,
-      hour: date.hour,
-      minute: date.min,
-      second: date.sec
+      year: clock.year,
+      month: clock.month,
+      day: clock.day,
+      hour: clock.hour,
+      minute: clock.min,
+      second: clock.sec
     }
-    send_command_and_confirm @task, command_list, "intention to set date"
+    send_command_and_confirm @task, command_list, "intention to set clock"
   end
 
-  def reset_date
+  def reset_clock
     require_security_codes
-    @site.log "Reset date", level: :test
+    Validator.log "Resetting clock", level: :test
     now = Time.now.utc
     command_list = build_command_list :M0104, :setDate, {
       securityCode: Validator.config['secrets']['security_codes'][1],
@@ -334,19 +334,19 @@ module CommandHelpers
       minute: now.min,
       second: now.sec
     }
-    send_command_and_confirm @task, command_list, "intention to set date"
+    send_command_and_confirm @task, command_list, "intention to set clock"
   end
 
-  def with_date_set date, &block
-    request, response = set_date date
+  def with_clock_set clock, &block
+    request, response = set_clock clock
     yield request,response
   ensure
-    reset_date
+    reset_clock
   end
 
 
   def wrong_security_code
-    @site.log "Try to force detector logic with wrong security code", level: :test
+    Validator.log "Try to force detector logic with wrong security code", level: :test
     command_list = build_command_list :M0008, :setForceDetectorLogic, {
       securityCode: '1111',
       status: 'True',

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -354,8 +354,9 @@ module CommandHelpers
     }
     component = Validator.config['components']['detector_logic'].keys[0]
     expect {
-      send_command_and_confirm @task, command_list, "rejection of wrong security code", component
+      send_command_and_confirm @task, command_list, "M0008 with wrong security code", component
     }.to raise_error(RSMP::MessageRejected)
+    Validator.log "Command rejected as expected", level: :test
   end
 
   def wait_normal_control

--- a/spec/support/formatter.rb
+++ b/spec/support/formatter.rb
@@ -125,8 +125,16 @@ class Details
       end
     end
 
+    if notification.pending_examples.any?
+      @output << "\n\nPending: (Failures listed here are expected and do not affect your suite's status):\n\n"
+      notification.pending_examples.each_with_index do |pending,i|
+        @output << "  #{i}) #{pending.full_description}\n".colorize(:yellow)
+        @output << "    # #{pending.location}\n\n".colorize(:cyan)
+      end
+    end
+
     if notification.failed_examples.any?
-      @output << "\n" << notification.colorized_rerun_commands(colorizer)
+      @output << "\n\n" << notification.colorized_rerun_commands(colorizer)
     end
 
     @output << "\n"

--- a/spec/support/formatter.rb
+++ b/spec/support/formatter.rb
@@ -1,0 +1,142 @@
+require 'rspec/core/formatters/console_codes'
+
+#class Extra
+#  RSpec::Core::Formatters.register self, :message
+#  def initialize output
+#    @output = output
+#  end
+#  def message notification # ExampleNotification
+#    @output << "Extra: #{notification.message}\n"
+#  end
+#end
+
+class Details
+  RSpec::Core::Formatters.register self, :start, :dump_pending, :dump_failures, :close,
+    :dump_summary, :example_started, :example_passed, :example_failed, :example_pending,
+    :message, :log, :step
+
+  def initialize output
+    @output = output
+  end
+
+  def start notification # StartNotification
+    @output << "\n"
+  end
+
+  def log notification # ExampleNotification
+    @output << "    #{notification.message}\n"
+  end
+
+  def step notification # ExampleNotification
+    @output << "  #{notification.message.colorize(:white)}\n"
+  end
+
+  def message notification # ExampleNotification
+    @output << "  #{notification.message}\n"
+  end
+
+  def example_started notification # ExampleNotification
+    @output <<  "#{notification.example.full_description}\n"
+  end
+
+  def example_passed notification # ExampleNotification
+    @output << "  Passed\n\n".colorize(:green)
+  end
+
+  def example_failed notification # FailedExampleNotification   
+    # RSpec::Core::Formatters::ExceptionPresenter is a private class which
+    # should really be used by us, but the snippet extraction and backtrace
+    # processing seems rather cumbersome to reimplement
+    presenter = RSpec::Core::Formatters::ExceptionPresenter.new(notification.example.execution_result.exception, notification.example, :indentation => 0)
+    
+    error = presenter.message_lines.map do |line|
+      "  #{line}"
+    end.join("\n").colorize(:red)
+    @output << error << "\n\n"
+
+    backtrace = presenter.formatted_backtrace.map do |line|
+      "  # #{line}"
+    end.join("\n").colorize(:light_blue)
+    @output << backtrace << "\n\n"
+  end
+
+  def example_pending notification # ExampleNotification
+    @output << RSpec::Core::Formatters::ConsoleCodes.wrap("Pending\n\n", :pending)
+  end
+
+  def dump_pending notification # ExamplesNotification
+    if notification.pending_examples.length > 0
+      @output << "\n\n#{RSpec::Core::Formatters::ConsoleCodes.wrap("PENDING:", :pending)}\n\t"
+      @output << notification.pending_examples.map {|example| example.full_description + " - " + example.location }.join("\n\t")
+    end
+  end
+
+  def dump_failures notification # ExamplesNotification
+    return
+    return if notification.failed_examples.empty?
+  
+    @output << "\n" << "Failures:" << "\n\n"
+
+    notification.failed_examples.each_with_index do |example, index|
+      presenter = RSpec::Core::Formatters::ExceptionPresenter.new(example.execution_result.exception, example, :indentation => 0)
+      @output << "  " << presenter.fully_formatted(nil) << "\n\n"
+
+      #@output << "#{index}) #{example.full_description}\n"
+      #@output << "#{index}) #{example.full_description}\n"
+      #@output << "\n"
+    end
+  end
+
+  def dump_summary notification # SummaryNotification
+    @output << "\n\nFinished in #{RSpec::Core::Formatters::Helpers.format_duration(notification.duration)}.\n\n"
+
+
+    str = "\n"
+    num_errors = Validator::Testee.sentinel_errors.size
+    if num_errors > 0
+      e = Validator::Testee.sentinel_errors.first
+      @output << "#{num_errors} sentinel warnings. First warning:\n#{e.class}: #{e}".colorize(:yellow)
+    else
+      @output << "No sentinel warnings."
+    end
+    @output << "\n\n"
+
+    @output << "Failed examples:\n\n"
+
+    notification.failed_examples.each do |example|
+      @output << "#{example.location.colorize(:red)} " << 
+        "# #{example.full_description}".colorize(:light_blue) << "\n"
+    end
+  end
+
+  def close notification # NullNotification
+    @output << "\n"
+  end
+
+  private
+
+
+  # Joins all exception messages
+  def build_examples_output output
+    output.join("\n\n")
+  end
+
+  # Extracts the full_description, location and formats the message of each example exception
+  def failed_example_output example
+    full_description = example.full_description
+    location = example.location
+    formatted_message = strip_message_from_whitespace(example.execution_result.exception.message)
+
+    "#{full_description} - #{location} \n  #{formatted_message}"
+  end
+
+  # Removes whitespace from each of the exception message lines and reformats it
+  def strip_message_from_whitespace msg
+    msg.split("\n").map(&:strip).join("\n#{add_spaces(10)}")
+  end
+
+  def add_spaces n
+    " " * n
+  end
+
+end

--- a/spec/support/formatter.rb
+++ b/spec/support/formatter.rb
@@ -50,18 +50,18 @@ class Details
     presenter = RSpec::Core::Formatters::ExceptionPresenter.new(notification.example.execution_result.exception, notification.example, :indentation => 0)
     
     error = presenter.message_lines.map do |line|
-      "  #{line}"
-    end.join("\n").colorize(:red)
-    @output << error << "\n\n"
+      "  #{line}\n".colorize(:red)
+    end.join
+    @output << error << "\n"
 
     backtrace = presenter.formatted_backtrace.map do |line|
-      "  # #{line}"
-    end.join("\n").colorize(:light_blue)
-    @output << backtrace << "\n\n"
+      "  # #{line}\n".colorize(:light_blue)
+    end.join
+    @output << backtrace << "\n"
   end
 
   def example_pending notification # ExampleNotification
-    @output << RSpec::Core::Formatters::ConsoleCodes.wrap("Pending\n\n", :pending)
+    @output << RSpec::Core::Formatters::ConsoleCodes.wrap("  Pending\n\n", :pending)
   end
 
   def dump_pending notification # ExamplesNotification

--- a/spec/support/formatter.rb
+++ b/spec/support/formatter.rb
@@ -101,7 +101,7 @@ class Details
     if Validator::Testee.sentinel_errors.any?
       max = 5
       warnings = Validator::Testee.sentinel_errors.first(max)
-      if warnings > max
+      if Validator::Testee.sentinel_errors.count > max
         @output << "\n\nSentinel warnings (showing first #{warnings.count}):\n\n"
       else
         @output << "\n\nSentinel warnings:\n\n"

--- a/spec/support/formatter.rb
+++ b/spec/support/formatter.rb
@@ -85,9 +85,9 @@ class Details
   def colorized_sentinel_warnings
     num_warnings = Validator::Testee.sentinel_errors.size
     if num_warnings > 0
-      "#{num_warnings} sentinel warnings.".colorize(:yellow)
+      "#{num_warnings} sentinel warnings".colorize(:yellow)
     else
-      "0 sentinel warnings."
+      "0 sentinel warnings"
     end
   end
 
@@ -99,8 +99,13 @@ class Details
                 "#{notification.colorized_totals_line(colorizer)}"
 
     if Validator::Testee.sentinel_errors.any?
-      warnings = Validator::Testee.sentinel_errors.first(5)
-      @output << "\nSentinel warnings: (showing #{warnings.count} of #{Validator::Testee.sentinel_errors.count}\n\n"
+      max = 5
+      warnings = Validator::Testee.sentinel_errors.first(max)
+      if warnings > max
+        @output << "\n\nSentinel warnings (showing first #{warnings.count}):\n\n"
+      else
+        @output << "\n\nSentinel warnings:\n\n"
+      end
       warnings.each do |warning|
         @output << "#{warning.class}: #{warning}\n".colorize(:yellow)
       end

--- a/spec/support/formatter.rb
+++ b/spec/support/formatter.rb
@@ -1,14 +1,28 @@
 require 'rspec/core/formatters/console_codes'
 
-#class Extra
-#  RSpec::Core::Formatters.register self, :message
-#  def initialize output
-#    @output = output
-#  end
-#  def message notification # ExampleNotification
-#    @output << "Extra: #{notification.message}\n"
-#  end
-#end
+module Validator
+  # Class used as a stream by the RSMP::Logger.
+  # When RSMP::Logger writes to it, the data
+  # is passed to an RSpec reporter, which
+  # will in turn distribute it to the active
+  # formatters, which can each write to a separate
+  # file, or to the console.
+
+  class ReportStream
+    def initialize rspec_reporter
+      @reporter = rspec_reporter
+    end
+
+    def puts str
+      @reporter.publish :log, message: str
+    end
+
+    def flush
+    end
+  end
+end
+
+
 
 class Details
   RSpec::Core::Formatters.register self, :start, :dump_pending, :dump_failures, :close,
@@ -28,7 +42,7 @@ class Details
   end
 
   def step notification # ExampleNotification
-    @output << "  #{notification.message}\n"
+    @output << "  #{notification.message}\n".colorize(:white)
   end
 
   def message notification # ExampleNotification

--- a/spec/support/formatters/brief.rb
+++ b/spec/support/formatters/brief.rb
@@ -29,7 +29,7 @@ class Brief < FormatterBase
     # expect { }.not_to raise_error might raise an RSpec::Expectations::ExpectationNotMetError,
     # with a messager that includes a backtrace. we don't want to show that here, so remove it
     message = notification.example.execution_result.exception.message
-    message.sub! /\s+with backtrace\:.*/m, ''
+    message = message.sub /\s+with backtrace\:.*/m, ''
     @output << colorize(" - Failed: #{message}\n",:white)
   end
 

--- a/spec/support/formatters/brief.rb
+++ b/spec/support/formatters/brief.rb
@@ -25,7 +25,12 @@ class Brief < FormatterBase
 
   def example_failed notification   
     @output << colorize("#{indent}#{notification.example.description}",:failure)
-    @output << colorize(" - Failed: #{notification.example.execution_result.exception}\n",:light_black) 
+
+    # expect { }.not_to raise_error might raise an RSpec::Expectations::ExpectationNotMetError,
+    # with a messager that includes a backtrace. we don't want to show that here, so remove it
+    message = notification.example.execution_result.exception.message
+    message.sub! /\s+with backtrace\:.*/m, ''
+    @output << colorize(" - Failed: #{message}\n",:white)
   end
 
   def example_pending notification

--- a/spec/support/formatters/brief.rb
+++ b/spec/support/formatters/brief.rb
@@ -1,141 +1,35 @@
 require 'rspec/core/formatters/console_codes'
 
-class Brief
+class Brief < FormatterBase
   RSpec::Core::Formatters.register self, :start, :dump_pending, :dump_failures, :close,
-    :dump_summary, :example_started, :example_passed, :example_failed, :example_pending,
-    :message, :log, :step, :example_group_started, :example_group_finished
-
-  def initialize output
-    @output = output
-    @level = 0
-  end
+    :dump_summary, :example_passed, :example_failed, :example_pending,
+    :example_group_started, :example_group_finished
 
   def indent
-    ' '*(@level*2)
-  end
-
-  def start notification
-    @output << "\n"
-  end
-
-  def log notification
-    #@output << "    #{notification.message}\n"
-  end
-
-  def step notification
-    #@output << "  #{notification.message}\n".colorize(:white)
-  end
-
-  def message notification
-    #@output << "  #{notification.message}\n"
+    ' '*(@groups.count*2)
   end
 
   def example_group_started notification
     @output <<  "#{indent}#{notification.group.description}\n"
-    @level += 1
+    super
   end
 
   def example_group_finished notification
-    @level -= 1
-    @output << "\n" if @level == 0
-  end
-
-  def example_started notification
-#    @output <<  "#{notification.example.full_description}\n".bold
+    super
+    @output << "\n" if @groups.empty?
   end
 
   def example_passed notification
-    @output <<  "#{indent}#{notification.example.description}\n".colorize(:green)
+    @output <<  colorize("#{indent}#{notification.example.description}\n",:success)
   end
 
   def example_failed notification   
-    # RSpec::Core::Formatters::ExceptionPresenter is a private class which
-    # should really be used by us, but the snippet extraction and backtrace
-    # processing seems rather cumbersome to reimplement
-    #presenter = RSpec::Core::Formatters::ExceptionPresenter.new(notification.example.execution_result.exception, notification.example, :indentation => 0)
-    #
-    #error = presenter.message_lines.map do |line|
-    #  "  #{line}\n".colorize(:red)
-    #end.join
-    #@output << error << "\n"
-
-    #backtrace = presenter.formatted_backtrace.map do |line|
-    #  "  # #{line}\n".colorize(:light_blue)
-    #end.join
-    #@output << backtrace << "\n"
-
-    @output << "#{indent}#{notification.example.description}".colorize(:red)
-    @output << " - #{notification.example.execution_result.exception}\n".colorize(:light_black)
-    
+    @output << colorize("#{indent}#{notification.example.description}",:failure)
+    @output << colorize(" - Failed: #{notification.example.execution_result.exception}\n",:light_black) 
   end
 
   def example_pending notification
-    @output << "#{indent}#{notification.example.description} - Pending\n".colorize(:yellow)
-  end
-
-  def dump_pending notification
-    #if notification.pending_examples.length > 0
-    #  @output << "\n\n#{RSpec::Core::Formatters::ConsoleCodes.wrap("Pending:", :pending)}\n\n"
-    #  @output << notification.pending_examples.map do |example|
-    #    "  #{example.full_description } - #{example.location}\n"
-    #  end.join
-    #end
-  end
-
-  def dump_failures notification
-    #return if notification.failed_examples.empty?
-    #@output << "\n" << "Failures:" << "\n\n"
-    #notification.failed_examples.each_with_index do |example, index|
-    #  presenter = RSpec::Core::Formatters::ExceptionPresenter.new(example.execution_result.exception, example, :indentation => 0)
-    #  @output << "  " << presenter.fully_formatted(nil) << "\n\n"
-    #end
-  end
-
-  def colorized_sentinel_warnings
-    num_warnings = Validator::Testee.sentinel_errors.size
-    if num_warnings > 0
-      "#{num_warnings} sentinel warnings".colorize(:yellow)
-    else
-      "0 sentinel warnings"
-    end
-  end
-
-  def dump_summary notification
-    colorizer = RSpec::Core::Formatters::ConsoleCodes
-    @output << "\nFinished in #{notification.formatted_duration} " \
-                "(files took #{notification.formatted_load_time} to load)\n" \
-                "#{colorized_sentinel_warnings}\n" \
-                "#{notification.colorized_totals_line(colorizer)}"
-
-    if Validator::Testee.sentinel_errors.any?
-      max = 5
-      warnings = Validator::Testee.sentinel_errors.first(max)
-      if Validator::Testee.sentinel_errors.count > max
-        @output << "\n\nSentinel warnings (showing first #{warnings.count}):\n\n"
-      else
-        @output << "\n\nSentinel warnings:\n\n"
-      end
-      warnings.each do |warning|
-        @output << "#{warning.class}: #{warning}\n".colorize(:yellow)
-      end
-    end
-
-    if notification.pending_examples.any?
-      @output << "\n\nPending: (Failures listed here are expected and do not affect your suite's status):\n\n"
-      notification.pending_examples.each_with_index do |pending,i|
-        @output << "  #{i}) #{pending.full_description}\n".colorize(:yellow)
-        @output << "    # #{pending.location}\n\n".colorize(:cyan)
-      end
-    end
-
-    if notification.failed_examples.any?
-      @output << "\n\n" << notification.colorized_rerun_commands(colorizer)
-    end
-
-    @output << "\n"
-  end
-
-  def close notification
-    @output << "\n"
+    @output << colorize("#{indent}#{notification.example.description} - " \
+      "Pending: #{notification.example.execution_result.pending_message}\n",:pending)
   end
 end

--- a/spec/support/formatters/details.rb
+++ b/spec/support/formatters/details.rb
@@ -35,7 +35,7 @@ class Details < FormatterBase
 
   def example_failed notification   
     # RSpec::Core::Formatters::ExceptionPresenter is a private class which
-    # should really be used by us, but the snippet extraction and backtrace
+    # should not really be used by us, but the snippet extraction and backtrace
     # processing seems rather cumbersome to reimplement
     presenter = RSpec::Core::Formatters::ExceptionPresenter.new(notification.example.execution_result.exception, notification.example, :indentation => 0)
     

--- a/spec/support/formatters/details.rb
+++ b/spec/support/formatters/details.rb
@@ -1,0 +1,132 @@
+require 'rspec/core/formatters/console_codes'
+
+class Details
+  RSpec::Core::Formatters.register self, :start, :dump_pending, :dump_failures, :close,
+    :dump_summary, :example_started, :example_passed, :example_failed, :example_pending,
+    :message, :log, :step, :example_group_started, :example_group_finished
+
+  def initialize output
+    @output = output
+    @level = 0
+    @groups = []
+  end
+
+  def start notification
+    @output << "\n"
+  end
+
+  def example_group_started notification
+    @groups.push notification.group.description
+  end
+
+  def example_group_finished notification
+    @groups.pop
+  end
+
+  def log notification
+    @output << "    #{notification.message}\n"
+  end
+
+  def step notification
+    @output << "  #{notification.message}\n".colorize(:white)
+  end
+
+  def message notification
+    @output << "  #{notification.message}\n"
+  end
+
+  def example_started notification
+    @output << "#{@groups.join(' / ')} / #{notification.example.description}\n".bold
+  end
+
+  def example_passed notification # ExampleNotification
+    @output << "  Passed\n\n".colorize(:green)
+  end
+
+  def example_failed notification   
+    # RSpec::Core::Formatters::ExceptionPresenter is a private class which
+    # should really be used by us, but the snippet extraction and backtrace
+    # processing seems rather cumbersome to reimplement
+    presenter = RSpec::Core::Formatters::ExceptionPresenter.new(notification.example.execution_result.exception, notification.example, :indentation => 0)
+    
+    error = presenter.message_lines.map do |line|
+      "  #{line}\n".colorize(:red)
+    end.join
+    @output << error << "\n"
+
+    backtrace = presenter.formatted_backtrace.map do |line|
+      "  # #{line}\n".colorize(:light_blue)
+    end.join
+    @output << backtrace << "\n"
+  end
+
+  def example_pending notification
+    @output << RSpec::Core::Formatters::ConsoleCodes.wrap("  Pending\n\n", :pending)
+  end
+
+  def dump_pending notification # ExamplesNotification
+    if notification.pending_examples.length > 0
+      @output << "\n\n#{RSpec::Core::Formatters::ConsoleCodes.wrap("Pending:", :pending)}\n\n"
+      @output << notification.pending_examples.map do |example|
+        "  #{example.full_description } - #{example.location}\n"
+      end.join
+    end
+  end
+
+  def dump_failures notification
+    return if notification.failed_examples.empty?
+    @output << "\n" << "Failures:" << "\n\n"
+    notification.failed_examples.each_with_index do |example, index|
+      presenter = RSpec::Core::Formatters::ExceptionPresenter.new(example.execution_result.exception, example, :indentation => 0)
+      @output << "  " << presenter.fully_formatted(nil) << "\n\n"
+    end
+  end
+
+  def colorized_sentinel_warnings
+    num_warnings = Validator::Testee.sentinel_errors.size
+    if num_warnings > 0
+      "#{num_warnings} sentinel warnings".colorize(:yellow)
+    else
+      "0 sentinel warnings"
+    end
+  end
+
+  def dump_summary notification
+    colorizer = RSpec::Core::Formatters::ConsoleCodes
+    @output << "\nFinished in #{notification.formatted_duration} " \
+                "(files took #{notification.formatted_load_time} to load)\n" \
+                "#{colorized_sentinel_warnings}\n" \
+                "#{notification.colorized_totals_line(colorizer)}"
+
+    if Validator::Testee.sentinel_errors.any?
+      max = 5
+      warnings = Validator::Testee.sentinel_errors.first(max)
+      if Validator::Testee.sentinel_errors.count > max
+        @output << "\n\nSentinel warnings (showing first #{warnings.count}):\n\n"
+      else
+        @output << "\n\nSentinel warnings:\n\n"
+      end
+      warnings.each do |warning|
+        @output << "#{warning.class}: #{warning}\n".colorize(:yellow)
+      end
+    end
+
+    if notification.pending_examples.any?
+      @output << "\n\nPending: (Failures listed here are expected and do not affect your suite's status):\n\n"
+      notification.pending_examples.each_with_index do |pending,i|
+        @output << "  #{i}) #{pending.full_description}\n".colorize(:yellow)
+        @output << "    # #{pending.location}\n\n".colorize(:cyan)
+      end
+    end
+
+    if notification.failed_examples.any?
+      @output << "\n\n" << notification.colorized_rerun_commands(colorizer)
+    end
+
+    @output << "\n"
+  end
+
+  def close notification
+    @output << "\n"
+  end
+end

--- a/spec/support/formatters/details.rb
+++ b/spec/support/formatters/details.rb
@@ -1,26 +1,12 @@
 require 'rspec/core/formatters/console_codes'
 
-class Details
+class Details < FormatterBase
   RSpec::Core::Formatters.register self, :start, :dump_pending, :dump_failures, :close,
     :dump_summary, :example_started, :example_passed, :example_failed, :example_pending,
     :message, :log, :step, :example_group_started, :example_group_finished
 
-  def initialize output
-    @output = output
-    @level = 0
-    @groups = []
-  end
-
   def start notification
     @output << "\n"
-  end
-
-  def example_group_started notification
-    @groups.push notification.group.description
-  end
-
-  def example_group_finished notification
-    @groups.pop
   end
 
   def log notification
@@ -28,19 +14,23 @@ class Details
   end
 
   def step notification
-    @output << "  #{notification.message}\n".colorize(:white)
+    @output << "> #{notification.message}\n"
   end
 
   def message notification
     @output << "  #{notification.message}\n"
   end
 
+  def example_pending notification
+    @output << colorize("  Pending\n\n", :pending)
+  end
+
   def example_started notification
-    @output << "#{@groups.join(' / ')} / #{notification.example.description}\n".bold
+    @output << colorize("#{@groups.join(' / ')} / #{notification.example.description}\n",:bold)
   end
 
   def example_passed notification # ExampleNotification
-    @output << "  Passed\n\n".colorize(:green)
+    @output << colorize("  Passed\n\n",:success)
   end
 
   def example_failed notification   
@@ -50,83 +40,14 @@ class Details
     presenter = RSpec::Core::Formatters::ExceptionPresenter.new(notification.example.execution_result.exception, notification.example, :indentation => 0)
     
     error = presenter.message_lines.map do |line|
-      "  #{line}\n".colorize(:red)
+      colorize("  #{line}\n",:failure)
     end.join
     @output << error << "\n"
 
     backtrace = presenter.formatted_backtrace.map do |line|
-      "  # #{line}\n".colorize(:light_blue)
+      colorize("  # #{line}\n",:light_blue)
     end.join
     @output << backtrace << "\n"
   end
 
-  def example_pending notification
-    @output << RSpec::Core::Formatters::ConsoleCodes.wrap("  Pending\n\n", :pending)
-  end
-
-  def dump_pending notification # ExamplesNotification
-    if notification.pending_examples.length > 0
-      @output << "\n\n#{RSpec::Core::Formatters::ConsoleCodes.wrap("Pending:", :pending)}\n\n"
-      @output << notification.pending_examples.map do |example|
-        "  #{example.full_description } - #{example.location}\n"
-      end.join
-    end
-  end
-
-  def dump_failures notification
-    return if notification.failed_examples.empty?
-    @output << "\n" << "Failures:" << "\n\n"
-    notification.failed_examples.each_with_index do |example, index|
-      presenter = RSpec::Core::Formatters::ExceptionPresenter.new(example.execution_result.exception, example, :indentation => 0)
-      @output << "  " << presenter.fully_formatted(nil) << "\n\n"
-    end
-  end
-
-  def colorized_sentinel_warnings
-    num_warnings = Validator::Testee.sentinel_errors.size
-    if num_warnings > 0
-      "#{num_warnings} sentinel warnings".colorize(:yellow)
-    else
-      "0 sentinel warnings"
-    end
-  end
-
-  def dump_summary notification
-    colorizer = RSpec::Core::Formatters::ConsoleCodes
-    @output << "\nFinished in #{notification.formatted_duration} " \
-                "(files took #{notification.formatted_load_time} to load)\n" \
-                "#{colorized_sentinel_warnings}\n" \
-                "#{notification.colorized_totals_line(colorizer)}"
-
-    if Validator::Testee.sentinel_errors.any?
-      max = 5
-      warnings = Validator::Testee.sentinel_errors.first(max)
-      if Validator::Testee.sentinel_errors.count > max
-        @output << "\n\nSentinel warnings (showing first #{warnings.count}):\n\n"
-      else
-        @output << "\n\nSentinel warnings:\n\n"
-      end
-      warnings.each do |warning|
-        @output << "#{warning.class}: #{warning}\n".colorize(:yellow)
-      end
-    end
-
-    if notification.pending_examples.any?
-      @output << "\n\nPending: (Failures listed here are expected and do not affect your suite's status):\n\n"
-      notification.pending_examples.each_with_index do |pending,i|
-        @output << "  #{i}) #{pending.full_description}\n".colorize(:yellow)
-        @output << "    # #{pending.location}\n\n".colorize(:cyan)
-      end
-    end
-
-    if notification.failed_examples.any?
-      @output << "\n\n" << notification.colorized_rerun_commands(colorizer)
-    end
-
-    @output << "\n"
-  end
-
-  def close notification
-    @output << "\n"
-  end
 end

--- a/spec/support/formatters/formatter_base.rb
+++ b/spec/support/formatters/formatter_base.rb
@@ -1,0 +1,62 @@
+require 'rspec/core/formatters/console_codes'
+
+class FormatterBase
+
+  def initialize output
+    @output = output
+    @groups = []
+  end
+
+  def colorize str, color
+    RSpec::Core::Formatters::ConsoleCodes.wrap str, color
+  end
+
+  def example_group_started notification
+    @groups.push notification.group.description
+  end
+
+  def example_group_finished notification
+    @groups.pop
+  end
+
+  def start notification
+    @output << "\n"
+  end
+
+  def dump_pending notification
+    dump_sentinel_warnings
+    if notification.pending_examples.any?
+      @output << notification.fully_formatted_pending_examples
+    end
+  end
+
+  def dump_sentinel_warnings
+      warnings = Validator::Testee.sentinel_errors
+    if warnings.any?      
+      @output << "\n\nSentinel warnings:\n\n"
+      warnings.each_with_index do |warning,i|
+        @output << colorize("#{i.to_s.rjust(4)}) #{warning.class}\n",:yellow)
+        @output << colorize("      #{warning.message}\n\n",:yellow)
+      end
+    end
+  end
+
+  def dump_failures notification
+    if notification.failed_examples.any?
+      @output << notification.fully_formatted_failed_examples
+    end
+  end
+
+  def dump_summary notification
+    @output << notification.fully_formatted
+
+    num = Validator::Testee.sentinel_errors.size
+    str = "#{num} sentinel warnings"
+    str = scolorize(str,:yellow) if num > 0
+    @output << "\n#{str}\n "
+  end
+
+  def close notification
+    @output << "\n"
+  end
+end

--- a/spec/support/formatters/formatter_base.rb
+++ b/spec/support/formatters/formatter_base.rb
@@ -36,7 +36,7 @@ class FormatterBase
       @output << "\n\nSentinel warnings:\n\n"
       warnings.each_with_index do |warning,i|
         @output << colorize("#{i.to_s.rjust(4)}) #{warning.class}\n",:yellow)
-        @output << colorize("      #{warning.message}\n\n",:yellow)
+        @output << "      #{warning.message}\n\n"
       end
     end
   end

--- a/spec/support/formatters/formatter_base.rb
+++ b/spec/support/formatters/formatter_base.rb
@@ -52,7 +52,7 @@ class FormatterBase
 
     num = Validator::Testee.sentinel_errors.size
     str = "#{num} sentinel warnings"
-    str = scolorize(str,:yellow) if num > 0
+    str = colorize(str,:yellow) if num > 0
     @output << "\n#{str}\n "
   end
 

--- a/spec/support/formatters/formatter_base.rb
+++ b/spec/support/formatters/formatter_base.rb
@@ -34,7 +34,7 @@ class FormatterBase
       warnings = Validator::Testee.sentinel_errors
     if warnings.any?      
       @output << "\n\nSentinel warnings:\n\n"
-      warnings.each_with_index do |warning,i|
+      warnings.each.with_index(1) do |warning,i|
         @output << colorize("#{i.to_s.rjust(4)}) #{warning.class}\n",:yellow)
         @output << "      #{warning.message}\n\n"
       end

--- a/spec/support/formatters/report_stream.rb
+++ b/spec/support/formatters/report_stream.rb
@@ -1,0 +1,24 @@
+module Validator
+  
+  # Class used as a stream by the RSMP::Logger
+  #
+  # When RSMP::Logger writes to it, the data
+  # is passed to an RSpec reporter, which
+  # will in turn distribute it to the active
+  # formatters.
+  #
+  # Formatters can write to separate file, or to the console.
+
+  class ReportStream
+    def initialize rspec_reporter
+      @reporter = rspec_reporter
+    end
+
+    def puts str
+      @reporter.publish :log, message: str
+    end
+
+    def flush
+    end
+  end
+end

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -13,6 +13,8 @@ module LogHelpers
     delay = Time.now - start_time
     upcase_first = action.sub(/\S/, &:upcase)
     Validator.log "#{upcase_first} confirmed after #{delay.to_i}s", level: :test
+  rescue Async::TimeoutError => e
+    raise RSMP::TimeoutError.new "Timeout while confirming #{action}"
   end
 
 end

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -1,24 +1,18 @@
 
-LOG_PATH = 'log/validation.log'
+#LOG_PATH = 'log/validation.log'
 
 # create log folder if it doesn't exist
-FileUtils.mkdir_p 'log'
+#FileUtils.mkdir_p 'log'
 
 
 module LogHelpers
   def log_confirmation action, &block
-    @site.log "Confirming #{action}", level: :test
+    Validator.log "Confirming #{action}", level: :test
     start_time = Time.now
     yield block
     delay = Time.now - start_time
     upcase_first = action.sub(/\S/, &:upcase)
-    @site.log "#{upcase_first} confirmed after #{delay.to_i}s", level: :test
-  end
-
-  def log str
-    File.open(LOG_PATH, 'a') do |file|
-      file.puts str
-    end
+    Validator.log "#{upcase_first} confirmed after #{delay.to_i}s", level: :test
   end
 
 end

--- a/spec/support/log_helpers.rb
+++ b/spec/support/log_helpers.rb
@@ -1,10 +1,3 @@
-
-#LOG_PATH = 'log/validation.log'
-
-# create log folder if it doesn't exist
-#FileUtils.mkdir_p 'log'
-
-
 module LogHelpers
   def log_confirmation action, &block
     Validator.log "Confirming #{action}", level: :test

--- a/spec/support/test_supervisor.rb
+++ b/spec/support/test_supervisor.rb
@@ -56,10 +56,10 @@ class Validator::Supervisor < Validator::Testee
 
     # reraise errors outside task to surface them in rspec
     if error
-      log "Failed: #{error.class}: #{error}", level: :test
+      Validator.log "Failed: #{error.class}: #{error}", level: :test
       raise error
     else
-      log "OK", level: :test
+      Validator.log "OK", level: :test
     end
   end
 
@@ -74,7 +74,7 @@ class Validator::Supervisor < Validator::Testee
     @site = klass.new(
       task: task,
       site_settings: config.deep_merge(options),
-      logger: @logger,
+      logger: Validator.logger,
       collect: options['collect']
     )
   end
@@ -82,7 +82,7 @@ class Validator::Supervisor < Validator::Testee
   def wait_for_connection
     @proxy = @node.proxies.first
     unless @proxy
-      log "Waiting for connection to supervisor", level: :test
+      Validator.log "Waiting for connection to supervisor", level: :test
       @proxy = @node.wait_for_supervisor(:any, config['timeouts']['connect'])
     end
     @proxy.wait_for_state :ready, config['timeouts']['ready']

--- a/spec/support/testee.rb
+++ b/spec/support/testee.rb
@@ -8,7 +8,7 @@ require 'rspec/expectations'
 
 class Validator::Testee 
   include RSpec::Matchers
-  include RSMP::Logging
+#  include RSMP::Logging
 
   @@sentinel_errors = []
 
@@ -79,19 +79,6 @@ class Validator::Testee
   def initialize
     parse_config
     @reactor = Async::Reactor.new
-    settings = {
-      'active' => true,
-      'port' => true,
-      'path' => LOG_PATH,    # from log_helpers.rb
-      'color' => true,
-      'json' => true,
-      'acknowledgements' => true,
-      'watchdogs' => true,
-      'test' => true
-    }
-    settings.merge!( config['log'] ) if config['log']
-    @logger = RSMP::Logger.new settings
-    initialize_logging logger: @logger
   end
 
   # Resume the reactor and run a block in an async task.
@@ -109,7 +96,7 @@ class Validator::Testee
         loop do
           @node.error_condition.wait  # if it's an exception, it will be raised
         rescue => e
-          log "Sentinel warning: #{e.class}: #{e}", level: :test
+          Validator.log "Sentinel warning: #{e.class}: #{e}", level: :test
           @@sentinel_errors << e
           #error = e
           #task.stop
@@ -124,10 +111,10 @@ class Validator::Testee
 
     # reraise errors outside task to surface them in rspec
     if error
-      log "Failed: #{error.class}: #{error}", level: :test
+      #Validator.log "Failed: #{error.class}: #{error}", level: :test
       raise error
     else
-      log "OK", level: :test
+      #Validator.log "OK", level: :test
     end
   end
 
@@ -152,7 +139,7 @@ class Validator::Testee
     # so run inside an Async block
     Async do
       if @node
-        log why, level: :test if why
+        Validator.log why, level: :test if why
         @node.stop
       end
       @node = nil

--- a/spec/support/testee.rb
+++ b/spec/support/testee.rb
@@ -94,12 +94,9 @@ class Validator::Testee
       task.async do |sentinel|
         sentinel.annotate 'sentinel'
         loop do
-          @node.error_condition.wait  # if it's an exception, it will be raised
-        rescue => e
+          e = @node.error_queue.dequeue
           Validator.log "Sentinel warning: #{e.class}: #{e}", level: :test
           @@sentinel_errors << e
-          #error = e
-          #task.stop
         end
       end
       yield task              # run block until it's finished

--- a/spec/support/testee.rb
+++ b/spec/support/testee.rb
@@ -8,7 +8,6 @@ require 'rspec/expectations'
 
 class Validator::Testee 
   include RSpec::Matchers
-#  include RSMP::Logging
 
   @@sentinel_errors = []
 

--- a/spec/support/testee.rb
+++ b/spec/support/testee.rb
@@ -147,4 +147,8 @@ class Validator::Testee
   # Wait for peer to be ready
   def wait_for_connection
   end
+
+  def parse_config
+  end
+  
 end

--- a/spec/support/validator.rb
+++ b/spec/support/validator.rb
@@ -2,33 +2,71 @@ require 'rsmp'
 require 'colorize'
 require 'rspec/expectations'
 
+
+# Class used as a stream by the RSMP::Logger.
+# When RSMP::Logger writes to it, the data
+# is passed to an RSpec reporter, which
+# will in turn distribute it to the active
+# formatters, which can each write to a separate
+# file, or to the console.
+
+class ReportStream
+  def initialize rspec_reporter
+    @reporter = rspec_reporter
+  end
+
+  def puts str
+    @reporter.publish :log, message: str
+  end
+
+  def flush
+    #@reporter.flush
+  end
+end
+
+
+
 module Validator
   include RSpec::Matchers
-  include RSMP::Logging
 
   class << self
-    attr_accessor :config, :mode
+    include RSMP::Logging
+    attr_accessor :config, :mode, :logger, :reporter
     attr_accessor :site_validator, :supervisor_validator
   end
 
   def self.setup rspec_config
+    setup_logging rspec_config
     determine_mode rspec_config.files_to_run
     load_config
     build_testee
     setup_filters rspec_config
   end
 
-  def self.after
-    str = "\n"
-    num_errors = Validator::Testee.sentinel_errors.size
-    if num_errors > 0
-      e = Validator::Testee.sentinel_errors.first
-      str << "#{num_errors} sentinel warnings. First warning: #{e.class}: #{e}".colorize(:yellow)
-    else
-      str << "No sentinel warnings.".colorize(:light_black)
-    end
-    puts str
-    log str
+  def self.setup_logging rspec_config
+    settings = {
+      'active' => true,
+      'port' => true,
+      'stream' => ReportStream.new(rspec_config.reporter),
+      'color' => {
+        'log' => 'light_black',
+        'test' => 'white'
+      },
+      'json' => true,
+      'acknowledgements' => true,
+      'watchdogs' => true,
+      'test' => true,
+      'direction' => false
+    }
+    initialize_logging log_settings: settings
+    self.reporter = rspec_config.reporter
+  end
+
+  def self.log str, options
+    self.reporter.publish :step, message: str
+  end
+
+  def self.after example
   end
 
   private
@@ -52,9 +90,7 @@ module Validator
         self.abort_with_error "Unknown test mode: #{mode}"
       end
 
-      message = "We're testing a #{mode}"
-      puts message
-      log message
+      #log "We're testing a #{mode}"
     end
   end
 
@@ -83,7 +119,7 @@ module Validator
 
     # load config
     if File.exist? config_path
-      puts "Loading config from #{config_path}"
+      #log "Loading config from #{config_path}"
       self.config = YAML.load_file config_path
     else
       self.abort_with_error "Config file #{config_path} is missing"
@@ -143,13 +179,13 @@ module Validator
     end
 
     unless self.config.dig 'secrets','security_codes'
-      puts "Warning: No security code configured".colorize(:yellow)
+      log "Warning: No security code configured".colorize(:yellow)
     else
       unless self.config.dig 'secrets','security_codes',1
-        puts "Warning: Security code 1 is not configured".colorize(:yellow)
+        log "Warning: Security code 1 is not configured".colorize(:yellow)
       end
       unless self.config.dig 'secrets','security_codes',2
-        puts "Warning: Security code 2 is not configured".colorize(:yellow)
+        log "Warning: Security code 2 is not configured".colorize(:yellow)
       end
     end
   end

--- a/spec/support/validator.rb
+++ b/spec/support/validator.rb
@@ -49,6 +49,7 @@ module Validator
       'port' => true,
       'stream' => ReportStream.new(rspec_config.reporter),
       'color' => {
+        'info' => 'white',
         'log' => 'light_black',
         'test' => 'white'
       },

--- a/spec/support/validator.rb
+++ b/spec/support/validator.rb
@@ -2,30 +2,6 @@ require 'rsmp'
 require 'colorize'
 require 'rspec/expectations'
 
-
-# Class used as a stream by the RSMP::Logger.
-# When RSMP::Logger writes to it, the data
-# is passed to an RSpec reporter, which
-# will in turn distribute it to the active
-# formatters, which can each write to a separate
-# file, or to the console.
-
-class ReportStream
-  def initialize rspec_reporter
-    @reporter = rspec_reporter
-  end
-
-  def puts str
-    @reporter.publish :log, message: str
-  end
-
-  def flush
-    #@reporter.flush
-  end
-end
-
-
-
 module Validator
   include RSpec::Matchers
 


### PR DESCRIPTION
An rspec formatter that shows what's normally shown in the log/validator.log file, but formattet a little bit differently.

using an rspec formatter has some benefits:
- cleaner
- output format can be selected using rspec command-line options.
- the output can include rspec stuff like summaries, backtraces, etc.
- we can use indentation for easier reading

