### PR TITLE
Reuse proxies when reconnecting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp'
+gem 'rsmp', path: '/Users/emiltin/Documents/code/rsmp'
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp', path: '/Users/emiltin/Documents/code/rsmp'
+gem 'rsmp', github: 'emiltin/rsmp'
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp', github: 'emiltin/rsmp'
+gem 'rsmp'
 gem 'rspec'
 gem 'activesupport'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
-PATH
-  remote: /Users/emiltin/Documents/code/rsmp
+GIT
+  remote: https://github.com/emiltin/rsmp.git
+  revision: f36855c1581ea69c569fadf3fe01ea99c5aa6ad8
   specs:
     rsmp (0.2.1)
       async (~> 1.29.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+PATH
+  remote: /Users/emiltin/Documents/code/rsmp
+  specs:
+    rsmp (0.2.1)
+      async (~> 1.29.1)
+      async-io (~> 1.32.1)
+      colorize (~> 0.8.1)
+      rsmp_schemer
+      thor (~> 1.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -7,12 +17,12 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    async (1.29.1)
+    async (1.29.2)
       console (~> 1.10)
       nio4r (~> 2.3)
       timers (~> 4.1)
-    async-io (1.32.1)
-      async (~> 1.14)
+    async-io (1.32.2)
+      async
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
     console (1.13.1)
@@ -30,15 +40,9 @@ GEM
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
     minitest (5.14.4)
-    nio4r (2.5.7)
+    nio4r (2.5.8)
     rake (13.0.6)
     regexp_parser (2.1.1)
-    rsmp (0.2.1)
-      async (~> 1.29.1)
-      async-io (~> 1.32.1)
-      colorize (~> 0.8.1)
-      rsmp_schemer
-      thor (~> 1.0.1)
     rsmp_schemer (0.3.1)
       json_schemer (~> 0.2.18)
     rspec (3.10.0)
@@ -70,7 +74,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   rake
-  rsmp
+  rsmp!
   rspec
   yard
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/emiltin/rsmp.git
-  revision: f36855c1581ea69c569fadf3fe01ea99c5aa6ad8
-  specs:
-    rsmp (0.2.1)
-      async (~> 1.29.1)
-      async-io (~> 1.32.1)
-      colorize (~> 0.8.1)
-      rsmp_schemer
-      thor (~> 1.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -44,6 +33,12 @@ GEM
     nio4r (2.5.8)
     rake (13.0.6)
     regexp_parser (2.1.1)
+    rsmp (0.2.2)
+      async (~> 1.29.1)
+      async-io (~> 1.32.1)
+      colorize (~> 0.8.1)
+      rsmp_schemer
+      thor (~> 1.0.1)
     rsmp_schemer (0.3.1)
       json_schemer (~> 0.2.18)
     rspec (3.10.0)
@@ -75,7 +70,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   rake
-  rsmp!
+  rsmp
   rspec
   yard
 

--- a/config/gem_supervisor.yaml
+++ b/config/gem_supervisor.yaml
@@ -29,7 +29,7 @@ intervals:
 timeouts:
   connect: 1
   ready: 1
-  watchdog: 1
+  watchdog: 3
   acknowledgement: 1
 secrets:
   security_codes:

--- a/spec/site/tlc/not_ready_debug.rb
+++ b/spec/site/tlc/not_ready_debug.rb
@@ -1,0 +1,12 @@
+RSpec.describe 'Traffic Light Controller' do  
+  include CommandHelpers
+  include StatusHelpers
+
+  it 'try to trigger NotReady' do |example|
+    Validator::Site.connected do |task,supervisor,site|
+      task.sleep 2
+      site.request_aggregated_status Validator.config['main_component']
+    end
+  end
+
+end


### PR DESCRIPTION
This PR fixes #114.

The current implementation will create a SiteProxy when a site connects. When the connection is closed, the object is discarded. If the site then reconnects a new SiteProxy is created.

But a test might still hang on the the old SiteObject, and try to use to to send messages, which will cause NotReady erorrs. This typically happens when you wait for a message, but this times out, and you rescue the timeout and try to do some rsmp cleanup, like unsubscribing to statuses, reset the clock, etc.

The fix is is to keep SiteProxy objects when a site disconnects. When a site connects it will look for an existing SiteProxy with a matching RMSP site id, and reuse it if found. That way tests that hang on to the SiteProxy object can still use it once the site is reconnected.

