### PR TITLE
Refactored wait methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     nio4r (2.5.8)
     rake (13.0.6)
     regexp_parser (2.1.1)
-    rsmp (0.2.3)
+    rsmp (0.3.0)
       async (~> 1.29.1)
       async-io (~> 1.32.1)
       colorize (~> 0.8.1)

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -57,18 +57,18 @@ RSpec.describe 'Site::Traffic Light Controller' do
             :minute,
             :second,
           ] }
-          request, matcher = site.request_status Validator.config['main_component'], convert_status_list(status_list), collect: {
+          request, collector = site.request_status Validator.config['main_component'], convert_status_list(status_list), collect: {
             timeout: Validator.config['timeouts']['status_update']
           }
           status = "S0096"
 
           received = Time.new(
-            matcher.result.dig( {"sCI" => status, "n" => "year"}, :item, 's' ),
-            matcher.result.dig( {"sCI" => status, "n" => "month"}, :item, 's' ),
-            matcher.result.dig( {"sCI" => status, "n" => "day"}, :item, 's' ),
-            matcher.result.dig( {"sCI" => status, "n" => "hour"}, :item, 's' ),
-            matcher.result.dig( {"sCI" => status, "n" => "minute"}, :item, 's' ),
-            matcher.result.dig( {"sCI" => status, "n" => "second"}, :item, 's' ),
+            collector.result.dig( {"sCI" => status, "n" => "year"}, :item, 's' ),
+            collector.result.dig( {"sCI" => status, "n" => "month"}, :item, 's' ),
+            collector.result.dig( {"sCI" => status, "n" => "day"}, :item, 's' ),
+            collector.result.dig( {"sCI" => status, "n" => "hour"}, :item, 's' ),
+            collector.result.dig( {"sCI" => status, "n" => "minute"}, :item, 's' ),
+            collector.result.dig( {"sCI" => status, "n" => "second"}, :item, 's' ),
             'UTC'
           )
 
@@ -104,13 +104,13 @@ RSpec.describe 'Site::Traffic Light Controller' do
             :second,
           ] }
           
-          request, matcher = site.request_status Validator.config['main_component'],
+          request, collector = site.request_status Validator.config['main_component'],
             convert_status_list(status_list),
             collect: {
               timeout: Validator.config['timeouts']['status_response']
             }
 
-          message = matcher.messages.first
+          message = collector.messages.first
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
           diff = Time.parse(message.attributes['sTs']) - CLOCK
           diff = diff.round          
@@ -132,11 +132,11 @@ RSpec.describe 'Site::Traffic Light Controller' do
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
-          request, response = site.request_aggregated_status Validator.config['main_component'], collect: {
+          request, collector = site.request_aggregated_status Validator.config['main_component'], collect: {
             timeout: Validator.config['timeouts']['status_response']
           }
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-          diff = Time.parse(response.attributes['aSTS']) - CLOCK
+          diff = Time.parse(collector.result.attributes['aSTS']) - CLOCK
           diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of aggregated status is off by #{diff}s, should be within #{max_diff}s"
@@ -155,8 +155,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
-          request, matcher = set_functional_position 'NormalControl'
-          message = matcher.messages.first
+          request, collector = set_functional_position 'NormalControl'
+          message = collector.messages.first
           max_diff = Validator.config['timeouts']['command_response'] * 2
           diff = Time.parse(message.attributes['cTS']) - CLOCK
           diff = diff.round
@@ -177,8 +177,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         with_clock_set CLOCK do
-          request, matcher = set_functional_position 'NormalControl'
-          message = matcher.messages.first
+          request, collector = set_functional_position 'NormalControl'
+          message = collector.messages.first
           max_diff = Validator.config['timeouts']['command_response']
           diff = Time.parse(message.attributes['cTS']) - CLOCK
           diff = diff.round
@@ -227,9 +227,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
         prepare task, site
         with_clock_set CLOCK do
           Validator.log "Checking watchdog timestamp", level: :test
-          response = site.collect task, type: "Watchdog", num: 1, timeout: Validator.config['timeouts']['watchdog']
+          collector = site.collect task, type: "Watchdog", num: 1, timeout: Validator.config['timeouts']['watchdog']
           max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-          diff = Time.parse(response.attributes['wTs']) - CLOCK
+          diff = Time.parse(collector.result.attributes['wTs']) - CLOCK
           diff = diff.round
           expect(diff.abs).to be <= max_diff,
             "Timestamp of watchdog is off by #{diff}s, should be within #{max_diff}s"

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -6,7 +6,7 @@ module Validator::CommandHelpers
           timeout: Validator.config['timeouts']['command_response']
         }
     end
-    return *result   # use splat '*' operator
+    result
   end
 
   # Build a RSMP command value list from a hash


### PR DESCRIPTION
Updates rsmp gem to use refactored methods for waiting for messages. Functionality has been moved to Collector sub-classes, and now return tow items: message, collector. Test have been updated accordingly.



