### PR TITLE
refactor async usage, update rsmp and related specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rsmp'
+gem 'rsmp', github: 'rsmp-nordic/rsmp', branch: 'async_refactor'
 gem 'activesupport'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/rsmp-nordic/rsmp.git
+  revision: 7bdf95902a8608695037187333003338d4d45a88
+  branch: async_refactor
+  specs:
+    rsmp (0.8.6)
+      async (~> 1.29.1)
+      async-io (~> 1.32.2)
+      colorize (~> 0.8.1)
+      rsmp_schemer
+      thor (~> 1.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -33,12 +45,6 @@ GEM
     nio4r (2.5.8)
     rake (13.0.6)
     regexp_parser (2.2.0)
-    rsmp (0.8.6)
-      async (~> 1.29.1)
-      async-io (~> 1.32.2)
-      colorize (~> 0.8.1)
-      rsmp_schemer
-      thor (~> 1.2.1)
     rsmp_schemer (0.3.2)
       json_schemer (~> 0.2.18)
     rspec (3.10.0)
@@ -72,7 +78,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   rake
-  rsmp
+  rsmp!
   rspec
   yard
 

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -18,7 +18,7 @@ timeouts:
   alarm: 1
   disconnect: 1
   shutdown: 1
-  startup_sequence: 6
+  startup_sequence: 5
 components:
   main:
     TC:

--- a/spec/site/core/disconnect_spec.rb
+++ b/spec/site/core/disconnect_spec.rb
@@ -16,9 +16,10 @@ RSpec.describe 'Site::Core' do
       timeout = Validator.config['timeouts']['disconnect']
       Validator::Site.isolated do |task,supervisor,site|
         supervisor.ignore_errors RSMP::DisconnectError do
+          Validator.log "Disabling acknowledgements, site should disconnect", level: :test
           def site.acknowledge original
           end
-          site.wait_for_state :stopped, timeout
+          site.wait_for_state :disconnected, timeout: timeout
         end
       rescue RSMP::TimeoutError
         raise "Site did not disconnect within #{timeout}s"
@@ -32,9 +33,10 @@ RSpec.describe 'Site::Core' do
       Validator::Site.isolated do |task,supervisor,site|
         timeout = Validator.config['timeouts']['disconnect']
         supervisor.ignore_errors RSMP::DisconnectError do
+          Validator.log "Disabling watchdogs, site should disconnect", level: :test
           def site.send_watchdog now=nil
           end
-          site.wait_for_state :stopped, timeout
+          site.wait_for_state :disconnected, timeout: timeout
         end
       rescue RSMP::TimeoutError
         raise "Site did not disconnect within #{timeout}s"

--- a/spec/site/tlc/signal_groups_spec.rb
+++ b/spec/site/tlc/signal_groups_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
         supervisor.ignore_errors RSMP::DisconnectError do
           verify_startup_sequence do
             set_restart
-            site.wait_for_state :stopped, Validator.config['timeouts']['shutdown']
-            site.wait_for_state :ready, Validator.config['timeouts']['ready']
+            site.wait_for_state :disconnected, timeout: Validator.config['timeouts']['shutdown']
+            site.wait_for_state :ready, timeout: Validator.config['timeouts']['ready']
           end
         end
       end

--- a/spec/site/tlc/system_spec.rb
+++ b/spec/site/tlc/system_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Site::Traffic Light Controller' do
         prepare task, site
         supervisor.ignore_errors RSMP::DisconnectError do
           set_restart
-          site.wait_for_state :stopped, Validator.config['timeouts']['shutdown']
+          site.wait_for_state :disconnected, timeout: Validator.config['timeouts']['shutdown']
         end
       end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Site::Traffic Light Controller' do
       # it also means we need a new Validator::Site.
       Validator::Site.isolated do |task,supervisor,site|
         prepare task, site
-        site.wait_for_state :ready, Validator.config['timeouts']['ready']
+        site.wait_for_state :ready, timeout: Validator.config['timeouts']['ready']
         wait_normal_control
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'async'
 require 'active_support/time'
 require 'fileutils'
 require 'rsmp'
@@ -19,6 +20,15 @@ require_relative 'support/formatters/list.rb'
 include RSpec
 include Validator::LogHelpers
 
+reactor = nil
+
+def wait_all(task = self)
+  task.children&.each do |child|
+    wait_all(child)
+  end
+  task.wait
+end
+
 # configure RSpec
 RSpec.configure do |config|
   Validator.setup config
@@ -34,10 +44,40 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do |example|
-    Validator.check_connection
-  rescue StandardError => e
-    STDERR.puts "Error: #{e}".colorize(:red)
-    raise
+    reactor = Async::Reactor.new
+    reactor.annotate 'reactor'
+    Validator::Testee.set_reactor reactor
+
+    # start a never-ending task.
+    # he purpose of this task is to be the parents task of tasks that need to persist
+    # between test, like the site/supervisor
+    task = reactor.async do |task|
+      task.annotate 'persistent'
+      loop do
+        task.sleep 1
+      end
+    end
+    Validator::Testee.set_task task
+
+    #Validator.check_connection
+  #rescue StandardError => e
+  #  STDERR.puts "Error: #{e}".colorize(:red)
+  #  raise
   end
+
+  config.after(:suite) do |example|
+    puts
+    reactor.stop
+  end
+
+  config.around(:each) do |example|
+    reactor.run do |task|
+      task.annotate 'rspec'
+      example.run
+    ensure
+      reactor.interrupt
+    end
+  end
+
 end
 

--- a/spec/support/status_helpers.rb
+++ b/spec/support/status_helpers.rb
@@ -56,7 +56,7 @@ module Validator::StatusHelpers
       subscribe_list = convert_status_list(status_list).map { |item| item.merge 'uRt'=>update_rate.to_s }
       begin
         result = @site.subscribe_to_status Validator.config['main_component'], subscribe_list, collect!: {
-          timeout: Validator.config['timeouts']['command']
+          timeout: timeout
         }
       ensure
         unsubscribe_list = convert_status_list(status_list).map { |item| item.slice('sCI','n') }


### PR DESCRIPTION
Refactor use of Async, update rsmp to branch that also updates Async usage.
All specs now pass with the TLC emulator, including tests that restart the emulator.