### PR TITLE
Investigate why M0001 test cases fail on ITC3

### DIFF
--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   test:
+    if: ${{ false }}
+
     runs-on: [ self-hosted, Windows, X64, ec2 ]
     steps:
     - name: Check out repository

--- a/.github/workflows/swarco_itc3.yml
+++ b/.github/workflows/swarco_itc3.yml
@@ -28,7 +28,7 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems
 
     - name: Run tests
-      run: bundle exec rspec --format Validator::Brief --format Validator::Details --out log/validation.log spec/site
+      run: bundle exec rspec --format Validator::Brief --format Validator::Details --out log/validation.log spec/site/tlc/modes_spec.rb:107
       env:
         SITE_CONFIG: config/swarco_itc3.yaml
 

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -163,7 +163,7 @@ module Validator::CommandHelpers
     )
   end
 
-  def switch_yellow_flash timeout_minutes: nil
+  def switch_yellow_flash timeout_minutes: 0
     set_functional_position 'YellowFlash', timeout_minutes: timeout_minutes
     wait_for_status(@task,
       "yellow flash",


### PR DESCRIPTION
The M0001 works when testing directly with the RSMP simulator.
Why does it fail when using RSpec?
