### PR TITLE
use 0 as default for timeout when switcing to yellow flash

### DIFF
--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -163,7 +163,7 @@ module Validator::CommandHelpers
     )
   end
 
-  def switch_yellow_flash timeout_minutes: nil
+  def switch_yellow_flash timeout_minutes: 0
     set_functional_position 'YellowFlash', timeout_minutes: timeout_minutes
     wait_for_status(@task,
       "yellow flash",


### PR DESCRIPTION
fixes missing timout=1 in M0001 commands