### PR TITLE
Use ubuntu-18.04 for ITC2 vm

### DIFF
--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Install prerequisites
         run: |
@@ -17,7 +17,6 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get -y --allow-downgrades install libpcre2-8-0=10.34-7
           sudo apt-get -y install wine32
 
       - name: Checkout repo


### PR DESCRIPTION
Installation of wine32 fails on ubuntu 20.04 for some reason