### PR TITLE
Add dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Build and push docker image
 
 on:
   push:
-    branches: [ docker ]
+    branches: [ master ]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+# This workflow will build a docker image and publish to github packages
+
+name: Build and push docker image
+
+on:
+  push:
+    branches: [ docker ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:latest
+COPY . .
+RUN bundle install
+EXPOSE 12111
+ENTRYPOINT [ "bundle", "exec", "rspec" ]
+CMD [ "spec/site" ]


### PR DESCRIPTION
Add Dockerfile to build docker images.

Create an image:
`docker image build -t rsmp_validator .`

Running a container:
`docker run --name rsmp_validator -v config:/config -p 12111:12111 rsmp_validator`
It runs `bundle exec rspec spec/site` by default. Also maps config/ for configuration files.

Running a container with custom rspec settings:
`docker container run --name rsmp_validator -v config:/config -p 12111:12111 rsmp_validator --format Validator::Brief --tag '~script' spec/site/tlc/detector_logics_spec.rb:31`

I've also created a Dockerfile for the rsmp gem, in the docker branch. It makes it easy to test the rsmp_validator with the rsmp gem using separate docker containers.