### PR TITLE
use sOc in subscribe message only for core 3.1.5 or higher

### DIFF
--- a/spec/site/tlc/subscribe_spec.rb
+++ b/spec/site/tlc/subscribe_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe 'Site::Traffic Light Controller' do
+  include Validator::StatusHelpers
+
   describe 'Subscription' do
     # Check that we can *subscribe* to status messages.
     # The test subscribes to S0001 (signal group status), because
@@ -14,8 +16,11 @@ RSpec.describe 'Site::Traffic Light Controller' do
       Validator::Site.connected do |task,supervisor,site|
         log "Subscribe to status and wait for update"
         component = Validator.config['main_component']
-        status_list = [{'sCI'=>'S0001','n'=>'signalgroupstatus','uRt'=>'1','sOc' => 'False'}]
-        site.subscribe_to_status component, status_list, collect!: {
+
+        status_list = [{'sCI'=>'S0001','n'=>'signalgroupstatus','uRt'=>'1'}]
+        status_list.map! { |item| item.merge!('sOc' => 'False') } if use_sOc?(site)
+
+         site.subscribe_to_status component, status_list, collect!: {
           timeout: Validator.config['timeouts']['status_update']
         }
       ensure

--- a/spec/site/tlc/system_spec.rb
+++ b/spec/site/tlc/system_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'Site::Traffic Light Controller' do
         { S0091: [:user] }
     end
 
-
     # Verify status S0092 operator logged in/out web-interface
     #
     # 1. Given the site is connected

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -409,7 +409,9 @@ module Validator::CommandHelpers
 
   def verify_startup_sequence &block
     status_list = [{'sCI'=>'S0001','n'=>'signalgroupstatus'}]
-    subscribe_list = convert_status_list(status_list).map { |item| item.merge 'uRt'=>0.to_s, 'sOc' => 'False' }
+    subscribe_list = convert_status_list(status_list).map { |item| item.merge 'uRt'=>0.to_s }
+    subscribe_list.map! { |item| item.merge!('sOc' => 'False') } if use_sOc?(@site)
+
     unsubscribe_list = convert_status_list(status_list)
     component = Validator.config['main_component']
     timeout = Validator.config['timeouts']['startup_sequence']

--- a/spec/support/status_helpers.rb
+++ b/spec/support/status_helpers.rb
@@ -86,11 +86,17 @@ module Validator::StatusHelpers
     end
   end
 
+  # Check if the core version of a site proxy satisfies
+  # a version string, e.g. ">=3.1.5".
+  # Uses Gem classes to perform action checks, although this
+  # has nothing to do with gems.
   def core_version_satisfies? site, condition
     core_version = Gem::Version.new(site.core_version)
     Gem::Requirement.new(condition).satisfied_by?(core_version)
   end
 
+  # Should the sOc attribute be used?
+  # It should if the core version is 3.1.5 or higher.
   def use_sOc? site
     core_version_satisfies? site, '>=3.1.5'
   end

--- a/spec/support/status_helpers.rb
+++ b/spec/support/status_helpers.rb
@@ -52,7 +52,9 @@ module Validator::StatusHelpers
       timeout: Validator.config['timeouts']['command']
     update_rate = 0 unless update_rate
     log "Wait for #{description}"
-    subscribe_list = convert_status_list(status_list).map { |item| item.merge 'uRt'=>update_rate.to_s , 'sOc' => 'False'}
+    subscribe_list = convert_status_list(status_list).map { |item| item.merge 'uRt'=>update_rate.to_s }
+    subscribe_list.map! { |item| item.merge!('sOc' => 'False') } if use_sOc?(@site)
+
     begin
       result = @site.subscribe_to_status Validator.config['main_component'], subscribe_list, collect!: {
         timeout: timeout
@@ -83,4 +85,14 @@ module Validator::StatusHelpers
       }
     end
   end
+
+  def core_version_satisfies? site, condition
+    core_version = Gem::Version.new(site.core_version)
+    Gem::Requirement.new(condition).satisfied_by?(core_version)
+  end
+
+  def use_sOc? site
+    core_version_satisfies? site, '>=3.1.5'
+  end
+
 end


### PR DESCRIPTION
Should fix #210. The sOc attribute is only used in subcsribe messages if core version is 3.1.5 or higher, as determing during the version exchange.

Adds these helpers to status_helpers.rb:

```ruby 
 # Check if the core version of a site proxy satisfies
  # a version string, e.g. ">=3.1.5".
  # Uses Gem classes to perform action checks, although this
  # has nothing to do with gems.
  def core_version_satisfies? site, condition

  # Should the sOc attribute be used?
  # It should if the core version is 3.1.5 or higher.
  def use_sOc? site
```
