### PR TITLE
Add support for 'source' field in several statuses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     nio4r (2.5.9)
     rake (13.0.6)
     regexp_parser (2.7.0)
-    rsmp (0.17.1)
+    rsmp (0.17.2)
       async (~> 1.30.3)
       async-io (~> 1.33.0)
       colorize (~> 0.8.1)

--- a/spec/site/tlc/modes_spec.rb
+++ b/spec/site/tlc/modes_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'switched on is read with S0007', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0007: [:status,:intersection] }
-        else
           status_list = { S0007: [:status,:intersection,:source] }
+        else
+          status_list = { S0007: [:status,:intersection] }
         end
         request_status_and_confirm site, "controller switch on (dark mode=off)", status_list
       end
@@ -63,9 +63,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'manual control is read with S0008', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0008: [:status,:intersection] }
-        else
           status_list = { S0008: [:status,:intersection,:source] }
+        else
+          status_list = { S0008: [:status,:intersection] }
         end
         request_status_and_confirm site, "manual control status", status_list
       end
@@ -79,9 +79,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'fixed time control is read with S0009', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0009: [:status,:intersection] }
-        else
           status_list = { S0009: [:status,:intersection,:source] }
+        else
+          status_list = { S0009: [:status,:intersection] }
         end
         request_status_and_confirm site, "fixed time control status", status_list
       end
@@ -109,9 +109,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'isolated control is read with S0010', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0010: [:status,:intersection] }
-        else
           status_list = { S0010: [:status,:intersection,:source] }
+        else
+          status_list = { S0010: [:status,:intersection] }
         end
         request_status_and_confirm site, "isolated control status", status_list
       end
@@ -126,9 +126,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'yellow flash can be read with S0011', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0011: [:status,:intersection] }
-        else
           status_list = { S0011: [:status,:intersection,:source] }
+        else
+          status_list = { S0011: [:status,:intersection] }
         end
         request_status_and_confirm site, "yellow flash status", status_list
       end
@@ -177,9 +177,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'all red can be read with S0012', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0012: [:status,:intersection] }
-        else
           status_list = { S0012: [:status,:intersection,:source] }
+        else
+          status_list = { S0012: [:status,:intersection] }
         end        
         request_status_and_confirm site, "all-red status", status_list
       end

--- a/spec/site/tlc/modes_spec.rb
+++ b/spec/site/tlc/modes_spec.rb
@@ -46,8 +46,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'switched on is read with S0007', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "controller switch on (dark mode=off)",
-          { S0007: [:status,:intersection] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0007: [:status,:intersection] }
+        else
+          status_list = { S0007: [:status,:intersection,:source] }
+        end
+        request_status_and_confirm site, "controller switch on (dark mode=off)", status_list
       end
     end
 
@@ -58,8 +62,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'manual control is read with S0008', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "manual control status",
-          { S0008: [:status,:intersection] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0008: [:status,:intersection] }
+        else
+          status_list = { S0008: [:status,:intersection,:source] }
+        end
+        request_status_and_confirm site, "manual control status", status_list
       end
     end
 
@@ -70,8 +78,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'fixed time control is read with S0009', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "fixed time control status",
-          { S0009: [:status,:intersection] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0009: [:status,:intersection] }
+        else
+          status_list = { S0009: [:status,:intersection,:source] }
+        end
+        request_status_and_confirm site, "fixed time control status", status_list
       end
     end
 
@@ -96,10 +108,15 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'isolated control is read with S0010', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "isolated control status",
-          { S0010: [:status,:intersection] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0010: [:status,:intersection] }
+        else
+          status_list = { S0010: [:status,:intersection,:source] }
+        end
+        request_status_and_confirm site, "isolated control status", status_list
       end
     end
+
 
     # Verify status S0011 yellow flash
     #
@@ -108,8 +125,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'yellow flash can be read with S0011', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "yellow flash status",
-          { S0011: [:status,:intersection] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0011: [:status,:intersection] }
+        else
+          status_list = { S0011: [:status,:intersection,:source] }
+        end
+        request_status_and_confirm site, "yellow flash status", status_list
       end
     end
 
@@ -155,8 +176,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'all red can be read with S0012', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "all-red status",
-          { S0012: [:status,:intersection] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0012: [:status,:intersection] }
+        else
+          status_list = { S0012: [:status,:intersection,:source] }
+        end        
+        request_status_and_confirm site, "all-red status", status_list
       end
     end
 

--- a/spec/site/tlc/signal_plans_spec.rb
+++ b/spec/site/tlc/signal_plans_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'currently active is read with S0014', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0014: [:status] }
-        else
           status_list = { S0014: [:status,:source] }
+        else
+          status_list = { S0014: [:status] }
         end
         request_status_and_confirm site, "current time plan", status_list
       end

--- a/spec/site/tlc/signal_plans_spec.rb
+++ b/spec/site/tlc/signal_plans_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     specify 'currently active is read with S0014', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "current time plan",
-          { S0014: [:status] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0014: [:status] }
+        else
+          status_list = { S0014: [:status,:source] }
+        end
+        request_status_and_confirm site, "current time plan", status_list
       end
     end
 

--- a/spec/site/tlc/traffic_situations_spec.rb
+++ b/spec/site/tlc/traffic_situations_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 3. Expect status response before timeout
     it 'is read with S0015', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "current traffic situation",
-          { S0015: [:status] }
+        if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
+          status_list = { S0015: [:status] }
+        else
+          status_list = { S0015: [:status,:source] }
+        end
+        request_status_and_confirm site, "current traffic situation", status_list
       end
     end
 

--- a/spec/site/tlc/traffic_situations_spec.rb
+++ b/spec/site/tlc/traffic_situations_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     it 'is read with S0015', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
-          status_list = { S0015: [:status] }
-        else
           status_list = { S0015: [:status,:source] }
+        else
+          status_list = { S0015: [:status] }
         end
         request_status_and_confirm site, "current traffic situation", status_list
       end


### PR DESCRIPTION
In SXL 1.1 the 'source' field was added to several statuses, S0007, S0008, S0009, S0010, S0011, S0012, S0014, S0015, S0032.

This PR adds separate tests cases for those statuses if >= SXL 1.1