### PR TITLE
activate inputs for raising alarms, and retire scripts

### DIFF
--- a/.github/workflows/gem_supervisor.yml
+++ b/.github/workflows/gem_supervisor.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Run tests
       shell: bash
-      run: bundle exec rspec --format Validator::Brief --format Validator::Details --out log/validation.log --tag '~script' spec/supervisor
+      run: bundle exec rspec --format Validator::Brief --format Validator::Details --out log/validation.log --tag '~programming' spec/supervisor
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
 

--- a/.github/workflows/gem_tlc.yml
+++ b/.github/workflows/gem_tlc.yml
@@ -35,7 +35,7 @@ jobs:
     
     - name: Run tests
       shell: bash
-      run: bundle exec rspec --format Validator::Brief --format Validator::Details --out log/validation.log --tag '~script' spec/site
+      run: bundle exec rspec --format Validator::Brief --format Validator::Details --out log/validation.log --tag '~programming' spec/site
       env:
         SITE_CONFIG: config/gem_tlc.yaml
     

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -42,6 +42,7 @@ secrets:
     1: '1111'
     2: '2222'
 alarm_activation:
-  A0301: 8
+  A0301: 7
+  A0302: 8
 restrict_testing:
 #  sxl_version: 1.1

--- a/config/simulator/tlc.yaml
+++ b/config/simulator/tlc.yaml
@@ -35,8 +35,10 @@ signal_plans:
 inputs:
   total: 8
   programming:
-    8:
+    7:
       raise: A0301
+    8:
+      raise: A0302
 intervals:
   timer: 0.1
   watchdog: 0.1

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The validator includes a growing suite of tests and can report test results in s
 ```
 % bundle exec rspec spec/site/core spec/site/tlc
 Using test config config/gem_tlc.yaml
-Run options: exclude {:rsmp=>[unless relevant for 3.1.5], :script=>true}
+Run options: exclude {:rsmp=>[unless relevant for 3.1.5]}
 ...............................................................................
 
 Finished in 6.22 seconds (files took 0.60681 seconds to load)

--- a/docs/pages/running.md
+++ b/docs/pages/running.md
@@ -30,7 +30,7 @@ Test a site, by running tests covering the core specification:
 ```
 % bundle exec rspec spec/site/core
 Using test config config/gem_tlc.yaml
-Run options: exclude {:rsmp=>[unless relevant for 3.1.5], :script=>true}
+Run options: exclude {:rsmp=>[unless relevant for 3.1.5]}
 ....
 
 Finished in 1.01 seconds (files took 0.64491 seconds to load)
@@ -49,7 +49,7 @@ If you want to store you selection for easy reuse, add them to a file name .rspe
 % cat .rspec-local
 --pattern spec/site/*   # run tests in spec/site/
 --exclude-pattern spec/site/unknown_status_spec.rb    # skip tests in this file
---tag ~script           # exclude tests tagged with :script
+--tag ~programming           # exclude tests tagged with :programming
 ```
 
  .rspec-local is git ignored, and will therefore not be added to the repo. 
@@ -85,23 +85,21 @@ Once it's running, you can run the validator site specs, and you will see the Ru
 
 See the [rsmp gem](https://github.com/rsmp-nordic/rsmp) documentation for details on how to run Ruby sites and supervisors.
 
-### Alarms and Scripts
+### Alarms and Programming
 Testing alarms require some way to trigger them.
 
-There's not yet any way to trigger alarms via RSMP, so some other way is required. Some equipment provide other interfaces that makes it possible to trigger alarms.
-
-If you can provide a script that can trigger the relevant alarms in the equipment, you can use this in tests. Such scripts are configured by adding `scripts` item in the validator config:
+There's not yet any way to trigger alarms directly via RSMP. But often you can program the equipment to raise an alarm when a specific input is activated. If that's the case, use the `alarm_activcation` item in the validator config to specify which input activates which alarm:
 
 ```yaml
-scripts:
-  activate_alarm: '/some/path/activate_alarm.sh'
-  deactivate_alarm: '/some/path/deactivate_alarm.sh'
+alarm_activation:
+  A0301: 7
+  A0302: 8
 ```
 
-Otherwise you should probably skip the test by passing the `--tag ~script` as an option to the `rspec` command:
+Tests that rely on device programming are tagged with :programming. If the device cannot be programmed to raise alarm on input activation, you should skip tests that rely on this, by passing the `--tag ~programming` as an option to the `rspec` command:
 
 ```
-% bundle exec rspec spec/site/ --tag ~script
+% bundle exec rspec spec/site/ --tag ~programming
 ```
  
 ## RSpec Helpers and Options

--- a/spec/site/tlc/alarm_spec.rb
+++ b/spec/site/tlc/alarm_spec.rb
@@ -2,165 +2,94 @@ RSpec.describe 'Site::Traffic Light Controller' do
   include Validator::CommandHelpers
   include Validator::StatusHelpers
 
-  
-  # Alarms can be hard to validate unless you have a reliable
-  # method of triggering them, and there is currently no way to directly triggering
-  # alarms via RSMP.
+  # Testing alarms require a reliable way of rainsing them.
   #
-  # Often some alarms can be triggered manually on the equipment,
-  # but since the validator is meant for automated testing, this approach is
-  # not used.
+  # There's no way to trigger alarms directly via RSMP yet,
+  # but often you can program the equipment to raise an alarm
+  # when a specific input is activated. If that's the case,
+  # set the `alarm_activcation` item in the validator config to
+  # specify which input activates which alarm. See docs for details.
   #
-  # Instead a separate interface which can be scripted, like SSH,
-  # must be used. If the equipment support this, you must set up scripts to
-  # activate and deactive alarms. These scripts will then be used in the tests
-  # to trigger alarms.
-  #
-  # If you have no way of triggering the relevant alarm via a scripts, skipping
-  # the test is recommended.
+  # Triggered alarms manually on the equipment is not used,
+  # because validator is meant for automated testing.
 
   describe 'Alarm' do
         
-    # Validate that a detector logic fault A0301 is raises and removed.
+    # Validate that a detector logic fault A0301 is raises and cleared.
     #
-    # The test expects that the TLC is programmed so that an alarm
-    # is raise when a specific input is activated. The alarm code and input nr
-    # is read from the test configuration.
+    # The test requires that the device is programmed so that the alarm
+    # is raise when a specific input is activated, as specified in the
+    # test configuration.
     #
     # 1. Given the site is connected
-    # 2. And we have forced the input to False
     # 2. When we force the input to True
-    # 3. Then we should receive an active alarm issue, with a reasonable timestamp
+    # 3. Then an alarm should be raised, with a timestamp close to now
     # 4. When we force the input to False
-    # 5. Then the alarm issue should become inactive, with a reasonable timestamp
-    specify 'Alarm A0301 is raised when input is activated', :script, sxl: '>=1.0.7' do |example|
-      alarm_code_id = 'A0301'   # what alarm to expect
-      skip "alarm activation is not configured" unless Validator.config['alarm_activation']
+    # 5. Then the alarm issue should become inactive, with a timestamp close to now
 
-      input_nr = Validator.config['alarm_activation'][alarm_code_id]  # what input to activate
-      skip "alarm activation for alarm #{alarm_code_id}  not configured" unless input_nr
-      
+    specify 'Alarm A0301 is raised when input is activated', :programming, sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
+        alarm_code_id = 'A0301'
         prepare task, site
-        timeout  = Validator.config['timeouts']['alarm']
-
-        # first force input to false, so we're sure to get an alarm when we afterwards force to true
-        force_input_and_confirm input:input_nr, value:'False'
-
-        # the rsmp spec requires a specific casing of enums, but some equipment uses incorrect casing.
-        # incorrect casing is usualle cuaght by the json schema validation, but in case this is disabled,
-        # we use case-insensitive regex patterns so that the tests can still be run
-        mapping = {
-          'True' => /Active/i,    # when input is forced to True, the alarm should become active
-          'False' => /inActive/i  # when input is forced to False, the alarm should become inactive
-        }
-
-        mapping.each_pair do |input_value, alarm_status|
-          log "Check that alarm #{alarm_code_id} becomes #{alarm_status.inspect} when we force input #{input_nr} to #{input_value}"
-          collect_task = task.async do  # run the collector in an async task
-            collector = RSMP::AlarmCollector.new( site,
-              num: 1,
-              query: { 'aCId' =>  alarm_code_id, 'aSp' =>  /Issue/i, 'aS' => alarm_status },
-              timeout: timeout
-            )
-            collector.collect!
-            alarm = collector.messages.first
-            alarm_time = Time.parse(alarm.attributes["aTs"])
-            expect(alarm_time).to be_within(1.minute).of Time.now.utc
-            log "Alarm #{alarm_code_id} is now #{alarm_status.inspect}"
-          end
-          force_input_and_confirm input:input_nr, value:input_value    # force the input
-          collect_task.wait                                            # and wait for the collector to complete
+        def verify_timestamp alarm, duration=1.minute
+          alarm_time = Time.parse(alarm.attributes["aTs"])
+          expect(alarm_time).to be_within(duration).of Time.now.utc
         end
+        deactivate = with_alarm_activated(task, site, alarm_code_id) do |alarm|   # raise alarm, by activating input
+          verify_timestamp alarm
+          log "Alarm #{alarm_code_id} is now Active"
+        end
+        verify_timestamp deactivate
+        log "Alarm #{alarm_code_id} is now Inactive"
       end
     end
 
-    # Validate that a detector logic fault raises A0302.
+    # Validate that a detector logic fault A0302 is raises and cleared.
+    #
+    # The test requires that the device is programmed so that the alarm
+    # is raise when a specific input is activated, as specified in the
+    # test configuration.
     #
     # 1. Given the site is connected
-    # 2. When we trigger an alarm using an external script
-    # 3. Then we should receive ana alarm
+    # 2. When we force the input to True
+    # 3. Then an alarm should be raised, with a timestamp close to now
+    # 4. When we force the input to False
+    # 5. Then the alarm issue should become inactive, with a timestamp close to now
 
-    specify 'A0302 is raised when a detector logic is faulty', :script, sxl: '>=1.0.7' do |example|
-      skip "Don't yet have a reliable way of triggering alarms"
-      skip_unless_scripts_are_configured
+    specify 'A0302 is raised when a detector logic is faulty', :programming, sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        component = Validator.config['components']['detector_logic'].keys.first
-        with_alarm_activated do
-          site.log "Waiting for alarm", level: :test
-          start_time = Time.now
-          alarm_code_id = 'A0301'
-          collector = site.collect_alarms num: 1, component: component, aCId: alarm_code_id,
-            aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
-
-          alarm = collector.message
-          delay = Time.now - start_time
-          site.log "alarm confirmed after #{delay.to_i}s", level: :test
-
+        alarm_code_id = 'A0302'
+        prepare task, site
+        def verify_timestamp alarm, duration=1.minute
           alarm_time = Time.parse(alarm.attributes["aTs"])
-          expect(alarm_time).to be_within(1.minute).of Time.now.utc
+          expect(alarm_time).to be_within(duration).of Time.now.utc
         end
+        deactivate = with_alarm_activated(task, site, alarm_code_id) do |alarm|   # raise alarm, by activating input
+          verify_timestamp alarm
+          log "Alarm #{alarm_code_id} is now Active"
+        end
+        verify_timestamp deactivate
+        log "Alarm #{alarm_code_id} is now Inactive"
       end
     end
 
     # Validate that an alarm can be acknowledged.
     #
     # 1. Given the site is connected
-    # 2. When we trigger an alarm using an external script
+    # 2. When we raise an alarm, by acticating an input
     # 3. Then we should receive an alarm
     # 4. When we acknowledgement the alarm
     # 5. Then we should receive a confirmation
 
-    it 'can be acknowledged', :script do |example|
-      skip "Don't yet have a reliable way of triggering alarms"
-      skip_unless_scripts_are_configured
+    it 'can be acknowledged', :programming do |example|
+      skip "Test case not ready"
       Validator::Site.connected do |task,supervisor,site|
-        component = Validator.config['components']['detector_logic'].keys.first
-
-        with_alarm_activated do
-          site.log "Waiting for alarm", level: :test
-          start_time = Time.now
-          message, response = nil,nil
-          alarm_code_id = 'A0301'
-
-          collector = site.collect_alarms num: 1, component: component, aCId: alarm_code_id,
-            aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
-        end
-        # TODO
-      end
-    end
-
-    # Validate that alarm triggered during a RSMP disconnect is buffered
-    # and send once the RSMP connection is reestablished.
-    #
-    # 1. Given the site is disconnected
-    # 2. And we trigger an alarm using an external script
-    # 3. When the site reconnects
-    # 4. Then we should received an alarm
-
-    it 'is buffered during disconnect', :script, sxl: '>=1.0.7' do |example|
-      skip "Don't yet have a reliable way of triggering alarms"
-      skip_unless_scripts_are_configured
-      Validator::Site.stop
-      with_alarm_activated do
-        Validator::Site.connected do |task,supervisor,site|
-          component = Validator.config['components']['detector_logic'].keys.first
-          log "Wait for alarm"
-          collector = site.collect_alarms num: 1, component: component, aCId: 'A0302',
-            aSp: 'Issue', aS: 'Active', timeout: Validator.config['timeouts']['alarm']
-
-          alarm = collector.message
-          alarm_time = Time.parse(alarm.attributes["aTs"])
-          expect(alarm_time).to be_within(1.minute).of Time.now.utc
-          expect(alarm.attributes['rvs']).to eq([{
-            "n"=>"detector","v"=>"1"},
-            {"n"=>"type","v"=>"loop"},
-            {"n"=>"errormode","v"=>"on"},
-            {"n"=>"manual","v"=>"True"},
-            {"n"=>"logicerror","v"=>"always_off"}
-          ])
+        @site = site
+        with_alarm_activated task, site, 'A0301' do |alarm|
+          # TODO verify that we can acknowledge the alarm
         end
       end
     end
+
   end
 end

--- a/spec/site/tlc/clock_spec.rb
+++ b/spec/site/tlc/clock_spec.rb
@@ -193,27 +193,25 @@ RSpec.describe 'Site::Traffic Light Controller' do
     end
 
     # Verify timestamp of alarm after changing clock
+    # The test requires the device to be programmed so that
+    # a A0301 alarm can be raise by activating a specific input, as
+    # configuted in the test config.
     #
     # 1. Given the site is connected
-    # 2. Send control command to set_clock
-    # 3. Wait for status = true
-    # 4. Trigger alarm from Script
-    # 5. Wait for alarm
-    # 6. Compare set_clock and alarm response timestamp
-    # 7. Expect the difference to be within max_diff
-    it 'is used for alarm timestamp', :script, sxl: '>=1.0.7' do |example|
-      skip_unless_scripts_are_configured
+    # 2. When we send a command to change the clock
+    # 3. And we raise an alarm, by acticate an input
+    # 4. Then we should receive an alarm
+    # 5. And the alarm timestamp should be close to the time set the clock to
+
+    it 'is used for alarm timestamp', :programming, sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
-        with_clock_set CLOCK do
-          component = Validator.config['components']['detector_logic'].keys.first
-          with_alarm_activated do
-            site.log "Waiting for alarm", level: :test
-            collector = site.collect_alarms task, num: 1, timeout: Validator.config['timeouts']['alarm']
+        with_clock_set CLOCK do                           # set clock
+          with_alarm_activated(task, site, 'A0301') do |alarm|   # raise alarm, by activating input
+            alarm_time = Time.parse( alarm.attributes["aTs"] )
             max_diff = Validator.config['timeouts']['command_response'] + Validator.config['timeouts']['status_response']
-            diff = Time.parse(collector.message.first.attributes['sTs']) - CLOCK
-            diff = diff.round
-            expect(diff.abs).to be <= max_diff,
+            diff = alarm_time - CLOCK
+            expect(diff.round.abs).to be <= max_diff,
               "Timestamp of alarm is off by #{diff}s, should be within #{max_diff}s"
           end
         end

--- a/spec/support/test_site.rb
+++ b/spec/support/test_site.rb
@@ -87,20 +87,6 @@ class Validator::Site < Validator::Testee
     ].each do |key|
       raise "config 'timeouts/#{key}' is missing" unless config['timeouts'][key]
     end
-
-
-    # scripts
-    if config['scripts']
-      Validator.log "Warning: Script path for activating alarm is missing or empty".colorize(:yellow) if config['scripts']['activate_alarm'] == {}
-      unless File.exist? config['scripts']['activate_alarm']
-        Validator.abort_with_error "Script at #{config['scripts']['activate_alarm']} for activating alarm is missing".colorize(:yellow)
-      end
-      Validator.log "Warning: Script path for deactivating alarm is missing or empty".colorize(:yellow) if config['scripts']['deactivate_alarm'] == {}
-      unless File.exist? config['scripts']['deactivate_alarm']
-        Validator.abort_with_error "Script at #{config['scripts']['deactivate_alarm']} for deactivating alarm is missing".colorize(:yellow)
-      end
-    end
-
   end
 
   # build local supervisor


### PR DESCRIPTION
Removes all support for external scripts as a way of activating alarms. Insteed we now rely on acticating inputs. 
Relevant tests have been refactored and now use the helper with_alarm_activated().
