### PR TITLE
merge #267 (fix itc2 workflow) to master

### DIFF
--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -18,12 +18,10 @@ jobs:
 
       - name: Install wine32
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
-          sudo mkdir -p /etc/apt/keyrings
-          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -sc)/winehq-$(lsb_release -sc).sources
-          sudo apt-get update
-          sudo apt-get -y install --install-recommends winehq-stable
+          sudo apt-get update -qq
+          sudo apt-get install -yqq --allow-downgrades libc6:i386 libgcc-s1:i386 libstdc++6:i386 wine
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -9,7 +9,7 @@ on:
     - cron:  '45 0 * * *'
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -9,7 +9,7 @@ on:
     - cron:  '45 0 * * *'
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install wine32
         run: |
           sudo dpkg --add-architecture i386
-          wget -nc https://dl.winehq.org/wine-builds/winehq.key
-          sudo mv winehq.key /usr/share/keyrings/winehq-archive.key
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
           wget -nc https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
           sudo mv winehq-jammy.sources /etc/apt/sources.list.d/
           sudo apt-get update

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -19,12 +19,11 @@ jobs:
       - name: Install wine32
         run: |
           sudo dpkg --add-architecture i386
+          sudo mkdir -p /etc/apt/keyrings
           sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
-          wget -nc https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
-          sudo mv winehq-jammy.sources /etc/apt/sources.list.d/
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -sc)/winehq-$(lsb_release -sc).sources
           sudo apt-get update
-          sudo apt-get -y install wine32
+          sudo apt-get -y install --install-recommends winehq-stable
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -9,7 +9,7 @@ on:
     - cron:  '45 0 * * *'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Install wine32
         run: |
           sudo dpkg --add-architecture i386
+          wget -nc https://dl.winehq.org/wine-builds/winehq.key
+          sudo mv winehq.key /usr/share/keyrings/winehq-archive.key
+          wget -nc https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
+          sudo mv winehq-jammy.sources /etc/apt/sources.list.d/
           sudo apt-get update
           sudo apt-get -y install wine32
 


### PR DESCRIPTION
#267 fixed the itc-2 workflow. a PR against the equipment triggers the EC-2, ITC-2 and ITC-3 tests, but when merged, the changes of course go to the equipment branch, so they are not yet in the master branch. the daily test runs are done from master, so we need to merge equipment to master, which this pr does.