### PR TITLE
use 99 (two digits) for M0015 test

### DIFF
--- a/spec/site/tlc/signal_plans_spec.rb
+++ b/spec/site/tlc/signal_plans_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe 'Site::Traffic Light Controller' do
     specify 'offset is set with M0015', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         plan = 1
-        status = 255
+        status = 99
         prepare task, site
         set_offset status, plan
       end


### PR DESCRIPTION
fixes #249.
we might allow three digits in the spec, but for know let's just use a number with two digits in the test.