### PR TITLE
fix missing titles in YARD html docs

### DIFF
--- a/yard/templates/default/context/html/specification.erb
+++ b/yard/templates/default/context/html/specification.erb
@@ -1,7 +1,7 @@
 <div class="specification">
   <div class="heading <%= row %>">
     <a name="<%= specification.unique_id %>"></a>
-    <%= specification.value %>
+    <%= specification.full_name %>
   </div>
 
   <div class="details method_details_list">


### PR DESCRIPTION
fixes missing title in the YARD html docs, eg: https://rsmp-nordic.org/rsmp_validator/dev/Specifications/Site/Traffic_20Light_20Controller/Detector_20Logic.html