### PR TITLE
dont require equipment label for scheduled workflow runs

### DIFF
--- a/.github/workflows/dynniq_ec2.yml
+++ b/.github/workflows/dynniq_ec2.yml
@@ -15,7 +15,7 @@ on:
     - cron:  '45 0 * * *'
 jobs:
   test:
-    if: ${{ github.event.label.name == 'equipment' }}
+    if: ${{ github.event_name == 'schedule' || github.event.label.name == 'equipment' }}
     runs-on: [ self-hosted, Windows, X64, ec2 ]
     steps:
     - name: Check out repository

--- a/.github/workflows/swarco_itc2.yml
+++ b/.github/workflows/swarco_itc2.yml
@@ -9,7 +9,7 @@ on:
     - cron:  '45 0 * * *'
 jobs:
   test:
-    if: ${{ github.event.label.name == 'equipment' }}
+    if: ${{ github.event_name == 'schedule' || github.event.label.name == 'equipment' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Install prerequisites

--- a/.github/workflows/swarco_itc3.yml
+++ b/.github/workflows/swarco_itc3.yml
@@ -15,7 +15,7 @@ on:
     - cron:  '45 0 * * *'
 jobs:
   test:
-    if: ${{ github.event.label.name == 'equipment' }}
+    if: ${{ github.event_name == 'schedule' || github.event.label.name == 'equipment' }}
     runs-on: [ self-hosted, Windows, X64, itc3 ]
     steps:
     - name: Check out repository


### PR DESCRIPTION
the scheduled equipment workflows where not running, because the 'equipment' label was required even on scheduled runs.

fixed with: `if: ${{ github.event_name == 'schedule' || github.event.label.name == 'equipment' }}`

