### PR TITLE
verify security codes only for sxl>=1.1

### DIFF
--- a/spec/site/tlc/system_spec.rb
+++ b/spec/site/tlc/system_spec.rb
@@ -88,7 +88,13 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
-    specify 'security code is rejected when incorrect', sxl: '>=1.0.7' do |example|
+    # Verify that the site responds with NotAck if we send incorrect security cdoes.
+    # RThis hehaviour is defined in SXL >= 1.1. For earlier versions,
+    # The behaviour is undefined.
+    # 1. Given the site is connected
+    # 2. When we send a M0008 command with incorrect security codes
+    # 3. Then we should received a NotAck
+    specify 'security code is rejected when incorrect', sxl: '>=1.1' do |example|
       Validator::Site.connected do |task,supervisor,site|
         prepare task, site
         expect { wrong_security_code }.to raise_error(RSMP::MessageRejected)


### PR DESCRIPTION
adfter discussion in https://github.com/rsmp-nordic/rsmp/issues/47#issuecomment-1602459967, we'll only verify behaviour when we send incorrect security codes if SXL>=1.

For earlierversion, the behaivour is (yet) undefined.
