### PR TITLE
work on test for S0035, S0006 and M0005

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     minitest (5.18.0)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    rsmp (0.22.0)
+    rsmp (0.23.0)
       async (~> 2.6.4)
       async-io (~> 1.36.0)
       colorize (~> 0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     minitest (5.18.0)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    rsmp (0.23.0)
+    rsmp (0.23.1)
       async (~> 2.6.4)
       async-io (~> 1.36.0)
       colorize (~> 0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     minitest (5.18.0)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    rsmp (0.23.1)
+    rsmp (0.24.0)
       async (~> 2.6.4)
       async-io (~> 1.36.0)
       colorize (~> 0.8.1)

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -34,7 +34,7 @@ components:
 items:
   plans: [1,2]
   traffic_situations: [1,2]
-  emergency_routes: [1]
+  emergency_routes: [1,2]
   inputs: [1,3,8]
   outputs: [1,3,8]
 startup_sequence: 'efg'

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -47,4 +47,4 @@ alarms:
     activation_input: 7
     component: DL1
 restrict_testing:
-  #sxl_version: 1.2
+  sxl_version: 1.2

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -47,4 +47,4 @@ alarms:
     activation_input: 7
     component: DL1
 restrict_testing:
-#  sxl_version: 1.1
+  #sxl_version: 1.2

--- a/config/simulator/tlc.yaml
+++ b/config/simulator/tlc.yaml
@@ -4,7 +4,7 @@ supervisors:
   - ip: 127.0.0.1
     port: 13111
 sxl: tlc
-sxl_version: 1.1
+sxl_version: 1.2
 components:
   main:
     TC:

--- a/spec/site/tlc/emergency_routes_spec.rb
+++ b/spec/site/tlc/emergency_routes_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Site::Traffic Light Controller' do
 
       def set_and_check_emergecy_states task, emergency_routes, state
         emergency_routes.each { |emergency_route| set_emergency_route emergency_route.to_s, state }
-        wait_for_status(task, "emergency route #{emergency_routes.last} to be enabled", a
+        wait_for_status(task, "emergency route #{emergency_routes.last} to be enabled",
           [
             {'sCI'=>'S0006','n'=>'status','s'=>(state ? 'True' : 'False')},
             {'sCI'=>'S0006','n'=>'emergencystage','s'=>emergency_routes.last.to_s}
@@ -71,10 +71,10 @@ RSpec.describe 'Site::Traffic Light Controller' do
 
       def set_and_check_emergecy_states task, emergency_routes, state
         emergency_routes.each { |emergency_route| set_emergency_route emergency_route.to_s, state }
+        routes = emergency_routes.map {|i| {'id'=>i.to_s} }
         wait_for_status(task, "emergency routes #{emergency_routes.to_s} to be enabled",
           [
-            {'sCI'=>'S0035','n'=>'status','s'=>[state ? 'True' : 'False']*emergency_routes.size},
-            {'sCI'=>'S0035','n'=>'emergencyroutes','s'=>emergency_routes}
+            {'sCI'=>'S0035','n'=>'emergencyroutes','s'=>routes}
           ]
         )
       end

--- a/spec/site/tlc/modes_spec.rb
+++ b/spec/site/tlc/modes_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
+    # Verify status S0005 traffic controller starting by intersection
+    #
+    # 1. Given the site is connected
+    # 2. Request status
+    # 3. Expect status response before timeout
+    specify 'startup status is read with S0005', sxl: '>=1.2' do |example|
+      Validator::Site.connected do |task,supervisor,site|
+        request_status_and_confirm site, "traffic controller starting (true/false)",
+          { S0005: [:statusByIntersection] }
+      end
+    end
+
     # Verify status S0007 controller switched on (dark mode=off)
     #
     # 1. Given the site is connected

--- a/spec/site/tlc/modes_spec.rb
+++ b/spec/site/tlc/modes_spec.rb
@@ -27,18 +27,6 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
-    # Verify status S0006 emergency stage
-    #
-    # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
-    specify 'emergency stage is read with S0006', sxl: '>=1.0.7' do |example|
-      Validator::Site.connected do |task,supervisor,site|
-        request_status_and_confirm site, "emergency stage status",
-          { S0006: [:status,:emergencystage] }
-      end
-    end
-
     # Verify status S0007 controller switched on (dark mode=off)
     #
     # 1. Given the site is connected

--- a/spec/site/tlc/signal_plans_spec.rb
+++ b/spec/site/tlc/signal_plans_spec.rb
@@ -36,11 +36,12 @@ RSpec.describe 'Site::Traffic Light Controller' do
     end
 
     # Verify status S0018 number of time plans
+    # Deprecated from 1.2, use S0022 instead.
     #
     # 1. Given the site is connected
     # 2. Request status
     # 3. Expect status response before timeout
-    specify 'list size is read with S0018', sxl: '>=1.0.7' do |example|
+    specify 'list size is read with S0018', sxl: ['>=1.0.7','<1.2'] do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "number of time plans",
           { S0018: [:number] }

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -128,14 +128,22 @@ module Validator::CommandHelpers
     # so do not expect it
   end
 
-  def set_emergency_route route
+  def set_emergency_route route, state
+    if state
+      enable_emergency_route route
+    else
+      disable_emergency_route route
+    end
+  end
+
+  def enable_emergency_route route
     require_security_codes
     command_list = build_command_list :M0005, :setEmergency, {
       securityCode: Validator.config['secrets']['security_codes'][2],
       status: 'True',
       emergencyroute: route
     }
-    send_command_and_confirm @task, command_list, "Set emergency route #{route}"
+    send_command_and_confirm @task, command_list, "Enable emergency route #{route}"
   end
 
   def disable_emergency_route route
@@ -541,26 +549,6 @@ module Validator::CommandHelpers
     wait_for_status(@task,
       "fixed time to be #{status}",
       [{'sCI'=>'S0009','n'=>'status','s'=>/^#{status}(,#{status})*$/}]
-    )
-  end
-
-  def switch_emergency_route route
-    set_emergency_route route
-    wait_for_status(@task,
-      "emergency route #{route} to be enabled",
-      [
-        {'sCI'=>'S0006','n'=>'status','s'=>'True'},
-        {'sCI'=>'S0006','n'=>'emergencystage','s'=>route}
-      ]
-    )
-
-    disable_emergency_route route
-    wait_for_status(@task,
-      "emergency route #{route} to be disabled",
-      [
-        {'sCI'=>'S0006','n'=>'status','s'=>'False'},
-        {'sCI'=>'S0006','n'=>'emergencystage','s'=>route}
-      ]
     )
   end
 


### PR DESCRIPTION
- [x] Add S0035 “emergency route” for supporting multiple active routes.
- [x] Update S0005 with ability get start up mode for each individual intersection. [[117]](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/117)
- [x] S0003 (deprecate “extendedinputstatus”) 
- [x] S0004 (deprecate “extendedoutputstatus”)
- [x] deprecate S0018 (number of time plans), use S0022 (list of time plans) instead.