### PR TITLE
add workflow for cross_rs4.yaml (2)

### DIFF
--- a/.github/workflows/cross_rs4.yaml
+++ b/.github/workflows/cross_rs4.yaml
@@ -1,0 +1,67 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will run rspec
+
+name: Cross RS4S
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, labeled ]
+  schedule:
+    # schedule runs only on the default branch. time is in UTC.
+    # * is a special character in YAML so you have to quote this string.
+    # run every night at 10:00PM UTC.
+    - cron:  '0 22 * * *'
+jobs:
+  validator:
+    if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
+    runs-on: [ self-hosted, Linux, X64, cross-rs4s ]
+    strategy:
+      matrix:
+        core: ['3.1.2', '3.1.3', '3.1.4', '3.1.5', '3.2.0', '3.2.1', '3.2.2']
+      fail-fast: false
+
+    steps:
+    - name: Set log id
+      shell: bash
+      id: log_id
+      run: |
+        echo "LOG_ID=\
+        cross-rs4s-\
+        core-${{ matrix.core }}-\
+        run-\
+        ${{ github.run_id }}-\
+        ${{ github.run_number }}-\
+        ${{ github.run_attempt }}\
+        " >> $GITHUB_OUTPUT
+
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Install Ruby and gems
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: '3.3.6'
+    - name: Run tests
+      run: |
+        bundle exec rspec spec/site \
+        --format Validator::Brief \
+        --format Validator::Details \
+        --out validator-${{ steps.log_id.outputs.LOG_ID }}.log
+      env:
+        SITE_CONFIG: config/cross_rs4s.yaml
+        CORE_VERSION: ${{ matrix.core}}
+
+    - name: Show detailed log
+      shell: bash
+      if: always() # even if previous steps failed
+      run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
+    
+    - name: Upload validator.log
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        path: validator-${{ steps.log_id.outputs.LOG_ID }}.log


### PR DESCRIPTION
based on  "add workflow for cross-rs4s #460" by Emil Tin 
fixed to ruby version 3.3.6 - as easiest way to make it run on Debian 12