### PR TITLE
M0018 empty strings

### DIFF
--- a/spec/site/tlc/signal_plans_spec.rb
+++ b/spec/site/tlc/signal_plans_spec.rb
@@ -260,30 +260,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # 6. Then reading cycle time should confirm the reversion
     specify 'cycle time is set with M0018', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
-        extension = 5
-
-        # read current plan
-        plan = read_current_plan(site)
-
-        # read initial cycle times
-        times = read_cycle_times(site)
-        time = times[plan]
-
-        # change cycle tme
-        time_extended = time + extension
-        need_to_reset = true
-        set_cycle_time plan, time_extended, "Extend cycle time to #{time_extended} for plan #{plan}"
-
-        # read updated cycle times
-        increase = 5
-        times = read_cycle_times(site, "updated cycle times")
-        time_extended_actual = times[plan]
-        expect(time_extended_actual).to eq(time_extended)
-
-      ensure
-        if need_to_reset
-          log "Reset cycle time"
-          set_cycle_time plan, time
+        with_cycle_time_extended(site) do
+          log "Cycle time extension confirmed"
         end
       end
     end

--- a/spec/site/tlc/signal_plans_spec.rb
+++ b/spec/site/tlc/signal_plans_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0014 current time plan
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'currently active is read with S0014', sxl: '>=1.0.7' do |example|
       Validator::Site.connected do |task,supervisor,site|
         if RSMP::Proxy.version_meets_requirement?( site.sxl_version, '>=1.1' )
@@ -23,9 +23,9 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # We try switching all programs configured
     #
     # 1. Given the site is connected
-    # 2. Verify that there is a Validator.get_config('validator') with a time plan
-    # 3. Send command to switch time plan
-    # 4. Wait for status "Current timeplan" = requested time plan
+    # 2. And there is a Validator.get_config('validator') with a time plan
+    # 3. When we send the command
+    # 3. We should receive a confirmative command response before timeout
     specify 'currently active is set with M0002', sxl: '>=1.0.7' do |example|
       plans = Validator.get_config('items','plans')
       skip("No time plans configured") if plans.nil? || plans.empty?
@@ -39,8 +39,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Deprecated from 1.2, use S0022 instead.
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'list size is read with S0018', sxl: ['>=1.0.7','<1.2'] do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "number of time plans",
@@ -51,8 +51,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0022 list of time plans
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'list is read with S0022', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "list of time plans",
@@ -63,8 +63,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0026 week time table
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'week table is read with S0026', sxl: '>=1.0.13'  do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "week time table",
@@ -72,9 +72,11 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
-    # 1. Verify connection
-    # 2. Send control command to set  week_table
-    # 3. Wait for status = true
+    # Verify that we can set week table with M0016
+    #
+    # 1. Given the site is connected
+    # 2. When we send the command
+    # 3. We should receive a confirmative command response before timeout
     specify 'week table is set with M0016', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         status = "0-1,6-2"
@@ -86,8 +88,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0027 time tables
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'day table is read with S0027', sxl: '>=1.0.13'  do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "command table",
@@ -95,9 +97,11 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
-    # 1. Verify connection
-    # 2. Send control command to set time_table
-    # 3. Wait for status = true
+    # Verify that we can set day table with M0017
+    #
+    # 1. Given the site is connected
+    # 2. When we send the command
+    # 3. We should receive a confirmative command response before timeout
     specify 'day table is set with M0017', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         status = "12-1-12-59,1-0-23-12"
@@ -109,8 +113,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0097 version of traffic program
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'version is read with S0097', sxl: '>=1.0.15' do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "version of traffic program",
@@ -121,8 +125,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0098 configuration of traffic parameters
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'config is read with S0098', sxl: '>=1.0.15' do |example|
       Validator::Site.connected do |task,supervisor,site|
         result = request_status_and_confirm site, "config of traffic parameters",
@@ -142,8 +146,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0023 command table
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'dynamic bands are read with S0023', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "command table",
@@ -151,9 +155,11 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
-    # 1. Verify connection
-    # 2. Send control command to set dynamic_bands
-    # 3. Wait for status = true
+    # Verify that dynamic bands can the set with M0014
+    #
+    # 1. Given the site is connected
+    # 2. When we send the command
+    # 3. We should receive a confirmative command response before timeout
     specify 'dynamic bands are set with M0014', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         plan = Validator.get_config('items','plans').first
@@ -163,12 +169,14 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
+    # Verify that dynamic bands can be read and changed
+    #
     # 1. Given the site is connected
-    # 2. Read dynamic band
-    # 3. Set dynamic band to 2x previous value
-    # 4. Read  band to confirm
-    # 5. Set dynamic band to previous value
-    # 6. Read dynamic band to confirm
+    # 2. And we read dynamic band
+    # 3. When we set dynamic band to 2x previous value
+    # 4. Then reading dynamic bands should confirm the change 
+    # 5. Finally when we revert dynamic band to previous value
+    # 6. Then reading dynamic bands should confirm the reversion
 
     specify 'dynamic bands values can be changed and read back', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
@@ -191,7 +199,7 @@ RSpec.describe 'Site::Traffic Light Controller' do
 
     # Verify command M0023 timeout of dynamic bands
     #
-    # 1. Verify connection
+    # 1. Given the site is connected
     # 2. When we send command to set timeout
     # 3. Then we should get a confirmation
     # 2. When we send command to disable timeout
@@ -233,8 +241,8 @@ RSpec.describe 'Site::Traffic Light Controller' do
     # Verify status S0028 cycle time
     #
     # 1. Given the site is connected
-    # 2. Request status
-    # 3. Expect status response before timeout
+    # 2. When we request the status
+    # 3. We should receive a status response before timeout
     specify 'cycle time is read with S0028', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         request_status_and_confirm site, "cycle time",
@@ -242,9 +250,14 @@ RSpec.describe 'Site::Traffic Light Controller' do
       end
     end
 
-    # 1. Verify connection
-    # 2. Send control command to set cycle time
-    # 3. Wait for status = true
+    # Verify that cycle time can be changed with M0018
+    #  
+    # 1. Given the site is connected
+    # 2. And we read cycle times 
+    # 3. When we extend cycle time of curent plan with 5s
+    # 4. Then reading the cycle time should confirm the change 
+    # 5. Finally when we revert cycle time to previous value
+    # 6. Then reading cycle time should confirm the reversion
     specify 'cycle time is set with M0018', sxl: '>=1.0.13' do |example|
       Validator::Site.connected do |task,supervisor,site|
         extension = 5


### PR DESCRIPTION
In the test for extending cycle time with M0018, S0028 is used to read and confirm the change. Ttere's now a check for empty cycle times returned in S0028.