### PR TITLE
clear cartesio bundler cache

### DIFF
--- a/.github/workflows/semaforica_cartesio.yaml
+++ b/.github/workflows/semaforica_cartesio.yaml
@@ -42,6 +42,7 @@ jobs:
     - name: Install Ruby and gems
       uses: ruby/setup-ruby@v1
       with:
+        self-hosted: true
         bundler-cache: true
         cache-version: 2
 

--- a/.github/workflows/semaforica_cartesio.yaml
+++ b/.github/workflows/semaforica_cartesio.yaml
@@ -43,6 +43,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+        cache-version: 1
 
     - name: Run tests
       run: |

--- a/.github/workflows/semaforica_cartesio.yaml
+++ b/.github/workflows/semaforica_cartesio.yaml
@@ -43,7 +43,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-        cache-version: 1
+        cache-version: 2
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Fix for #531, the cartesio runner fails to install gems with bundler.

This PR clears the cache according to https://github.com/ruby/setup-ruby?tab=readme-ov-file#dealing-with-a-corrupted-cache.



