### PR TITLE
compliance collection

### DIFF
--- a/.github/workflows/compliance_collect.yaml
+++ b/.github/workflows/compliance_collect.yaml
@@ -1,0 +1,95 @@
+name: Collect Compliance Results
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: compliance-collector
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout validator
+        uses: actions/checkout@v4
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Checkout website main
+        uses: actions/checkout@v4
+        with:
+          repository: rsmp-nordic/rsmp_website
+          ref: main
+          path: rsmp_website
+          token: ${{ secrets.RSMP_WEBSITE_TOKEN }}
+
+      - name: Checkout website compliance data
+        uses: actions/checkout@v4
+        with:
+          repository: rsmp-nordic/rsmp_website
+          ref: main
+          fetch-depth: 0
+          path: rsmp_website_compliance_data
+          token: ${{ secrets.RSMP_WEBSITE_TOKEN }}
+
+      - name: Prepare compliance data branch
+        shell: bash
+        run: |
+          cd rsmp_website_compliance_data
+          if git ls-remote --exit-code origin compliance-data; then
+            git fetch origin compliance-data
+            git checkout compliance-data
+            echo "COMPLIANCE_DATA_BRANCH_EXISTS=true" >> $GITHUB_ENV
+          else
+            git checkout --orphan compliance-data
+            git rm -rf .
+            echo "COMPLIANCE_DATA_BRANCH_EXISTS=false" >> $GITHUB_ENV
+          fi
+
+      - name: Collect compliance data
+        run: bundle exec ruby exe/compliance-collector --website-dir rsmp_website --data-dir rsmp_website_compliance_data
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Commit compliance data
+        shell: bash
+        run: |
+          cd rsmp_website_compliance_data
+          git config user.name "GitHub Action"
+          git config user.email "actions@github.com"
+          git add summary.json runs
+          if git diff --cached --quiet; then
+            echo "No compliance data changes"
+            exit 0
+          fi
+          git commit -m "Update compliance data"
+          if [ "$COMPLIANCE_DATA_BRANCH_EXISTS" = "true" ]; then
+            git pull --rebase origin compliance-data
+          fi
+          git push origin HEAD:compliance-data
+
+      - name: Commit website summary
+        shell: bash
+        run: |
+          cd rsmp_website
+          git config user.name "GitHub Action"
+          git config user.email "actions@github.com"
+          git add _data/compliance/summary.json
+          if git diff --cached --quiet; then
+            echo "No website summary changes"
+            exit 0
+          fi
+          git commit -m "Update compliance summary"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/compliance_collect.yaml
+++ b/.github/workflows/compliance_collect.yaml
@@ -38,24 +38,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rsmp-nordic/rsmp_website
-          ref: main
-          fetch-depth: 0
+          ref: compliance-data
           path: rsmp_website_compliance_data
           token: ${{ secrets.RSMP_WEBSITE_TOKEN }}
-
-      - name: Prepare compliance data branch
-        shell: bash
-        run: |
-          cd rsmp_website_compliance_data
-          if git ls-remote --exit-code origin compliance-data; then
-            git fetch origin compliance-data
-            git checkout compliance-data
-            echo "COMPLIANCE_DATA_BRANCH_EXISTS=true" >> $GITHUB_ENV
-          else
-            git checkout --orphan compliance-data
-            git rm -rf .
-            echo "COMPLIANCE_DATA_BRANCH_EXISTS=false" >> $GITHUB_ENV
-          fi
 
       - name: Collect compliance data
         run: bundle exec ruby exe/compliance-collector --website-dir rsmp_website --data-dir rsmp_website_compliance_data
@@ -74,9 +59,7 @@ jobs:
             exit 0
           fi
           git commit -m "Update compliance data"
-          if [ "$COMPLIANCE_DATA_BRANCH_EXISTS" = "true" ]; then
-            git pull --rebase origin compliance-data
-          fi
+          git pull --rebase origin compliance-data
           git push origin HEAD:compliance-data
 
       - name: Commit website summary

--- a/.github/workflows/cross_rs4s.yaml
+++ b/.github/workflows/cross_rs4s.yaml
@@ -11,7 +11,7 @@ on:
     # schedule runs only on the default branch. time is in UTC.
     # * is a special character in YAML so you have to quote this string.
     # run every night at 10:00PM UTC.
-    - cron:  '0 22 * * *'
+    - cron: '0 22 * * *'
 jobs:
   validator:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
@@ -44,21 +44,31 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
+      shell: bash
       run: |
         bundle exec rsmp-validator test/site \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SITE_CONFIG: config/cross_rs4s.yaml
         CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn

--- a/.github/workflows/gem_supervisor.yaml
+++ b/.github/workflows/gem_supervisor.yaml
@@ -4,7 +4,10 @@
 # documentation.
 # This workflow will run rsmp validator
 name: Gem supervisor
-on: push
+on:
+  push:
+  schedule:
+    - cron: '0 22 * * *'
 jobs:
   validator:
     timeout-minutes: 10
@@ -20,8 +23,7 @@ jobs:
       id: log_id
       run: |
         echo "LOG_ID=\
-        gem-supervisor-\
-        ubuntu-latest-\
+        gem-supervisor-ubuntu-latest-\
         core-${{ matrix.core }}-\
         run-\
         ${{ github.run_id }}-\
@@ -35,14 +37,12 @@ jobs:
     - name: Install Ruby and gems
       uses: ruby/setup-ruby@v1
       with:
-        # ruby-version is not needed because we have a .tool-versions file
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
 
     - name: Start supervisor in background
       shell: bash
       run: |
-        bundle exec rsmp supervisor \
-        --config config/simulator/supervisor.yaml \
+        bundle exec rsmp supervisor --config config/simulator/supervisor.yaml \
         2>&1 > simulator-${{ steps.log_id.outputs.LOG_ID }}.log \
         &
 
@@ -50,23 +50,32 @@ jobs:
       shell: bash
       run: |
         bundle exec rsmp-validator test/supervisor \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SUPERVISOR_CONFIG: config/gem_supervisor.yaml
         CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn
+
     - name: Upload simulator.log
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/gem_tlc.yaml
+++ b/.github/workflows/gem_tlc.yaml
@@ -4,7 +4,10 @@
 # documentation.
 # This workflow will run rsmp validator
 name: Gem TLC
-on: push
+on:
+  push:
+  schedule:
+    - cron: '0 22 * * *'
 jobs:
   validator:
     timeout-minutes: 10
@@ -20,8 +23,7 @@ jobs:
       id: log_id
       run: |
         echo "LOG_ID=\
-        gem-tlc-\
-        ubuntu-latest-\
+        gem-tlc-ubuntu-latest-\
         core-${{ matrix.core }}-\
         run-\
         ${{ github.run_id }}-\
@@ -41,33 +43,40 @@ jobs:
     - name: Start TLC in background
       shell: bash
       run: |
-        bundle exec rsmp site \
-        --config config/simulator/tlc.yaml \
+        bundle exec rsmp site --config config/simulator/tlc.yaml \
         2>&1 > simulator-${{ steps.log_id.outputs.LOG_ID }}.log \
         &
-    
+
     - name: Run tests
       shell: bash
       run: |
         bundle exec rsmp-validator test/site \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
-        
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SITE_CONFIG: config/gem_tlc.yaml
         CORE_VERSION: ${{ matrix.core}}
-    
+
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn
+
     - name: Upload simulator.log
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/kapsch_etx.yaml
+++ b/.github/workflows/kapsch_etx.yaml
@@ -11,7 +11,7 @@ on:
     # schedule runs only on the default branch. time is in UTC.
     # * is a special character in YAML so you have to quote this string.
     # run every night at 10:00PM UTC.
-    - cron:  '0 22 * * *'
+    - cron: '0 22 * * *'
 jobs:
   validator:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
@@ -44,21 +44,31 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
+      shell: bash
       run: |
         bundle exec rsmp-validator test/site \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SITE_CONFIG: config/kapsch_etx.yaml
         CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn

--- a/.github/workflows/lightmotion_satellite.yaml
+++ b/.github/workflows/lightmotion_satellite.yaml
@@ -11,7 +11,7 @@ on:
     # schedule runs only on the default branch. time is in UTC.
     # * is a special character in YAML so you have to quote this string.
     # run every night at 10:00PM UTC.
-    - cron:  '0 22 * * *'
+    - cron: '0 22 * * *'
 jobs:
   validator:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
@@ -44,21 +44,31 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
+      shell: bash
       run: |
         bundle exec rsmp-validator test/site \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SITE_CONFIG: config/lightmotion_satellite.yaml
         CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn

--- a/.github/workflows/semaforica_cartesio.yaml
+++ b/.github/workflows/semaforica_cartesio.yaml
@@ -11,7 +11,7 @@ on:
     # schedule runs only on the default branch. time is in UTC.
     # * is a special character in YAML so you have to quote this string.
     # run every night at 10:00PM UTC.
-    - cron:  '0 22 * * *'
+    - cron: '0 22 * * *'
 jobs:
   validator:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
@@ -44,21 +44,31 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
+      shell: bash
       run: |
         bundle exec rsmp-validator test/site \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SITE_CONFIG: config/semaforica_cartesio.yaml
         CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn

--- a/.github/workflows/swarco_itc3.yaml
+++ b/.github/workflows/swarco_itc3.yaml
@@ -11,7 +11,7 @@ on:
     # schedule runs only on the default branch. time is in UTC.
     # * is a special character in YAML so you have to quote this string.
     # run every night at 10:00PM UTC.
-    - cron:  '0 22 * * *'
+    - cron: '0 22 * * *'
 jobs:
   validator:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
@@ -44,21 +44,31 @@ jobs:
         bundler-cache: true
 
     - name: Run tests
+      shell: bash
       run: |
         bundle exec rsmp-validator test/site \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SITE_CONFIG: config/swarco_itc3.yaml
         CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
-    
+
     - name: Upload validator.log
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn

--- a/.github/workflows/tecsen_tmacs.yaml
+++ b/.github/workflows/tecsen_tmacs.yaml
@@ -1,5 +1,8 @@
-# GitHub action for testing the TMAC supervisor system using the RSMP Validator
-
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will run rsmp validator
 name: TECSEN TMacs
 on:
   pull_request:
@@ -8,7 +11,7 @@ on:
     # schedule runs only on the default branch. time is in UTC.
     # * is a special character in YAML so you have to quote this string.
     # run every night at 10:00PM UTC.
-    - cron:  '0 22 * * *'
+    - cron: '0 22 * * *'
 jobs:
   validator:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'testhub') }}
@@ -32,7 +35,7 @@ jobs:
         ${{ github.run_attempt }}\
         " >> $GITHUB_OUTPUT
 
-    - name: Checkout repo
+    - name: Check out repository
       uses: actions/checkout@v4
 
     - name: Install Ruby and gems
@@ -44,14 +47,15 @@ jobs:
       shell: bash
       run: |
         bundle exec rsmp-validator test/supervisor \
-        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log
-
+        --verbose --log validator-${{ steps.log_id.outputs.LOG_ID }}.log \
+        --report-json compliance-${{ steps.log_id.outputs.LOG_ID }}.json
       env:
         SUPERVISOR_CONFIG: config/tecsen_tmacs_supervisor.yaml
+        CORE_VERSION: ${{ matrix.core}}
 
     - name: Show detailed log
       shell: bash
-      if: always() # even if previous steps failed
+      if: always()
       run: cat validator-${{ steps.log_id.outputs.LOG_ID }}.log
 
     - name: Upload validator.log
@@ -60,3 +64,11 @@ jobs:
       with:
         name: validator-${{ steps.log_id.outputs.LOG_ID }}.log
         path: validator-${{ steps.log_id.outputs.LOG_ID }}.log
+
+    - name: Upload compliance result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        path: compliance-${{ steps.log_id.outputs.LOG_ID }}.json
+        if-no-files-found: warn

--- a/config/cross_rs4s.yaml
+++ b/config/cross_rs4s.yaml
@@ -1,6 +1,12 @@
 # Config for testing Cross RS4S traffic light controller.
 # The settings are used for starting a local supervisor listening for the site tested
 # See https://rsmp-nordic.github.io/rsmp_validator/config/
+compliance:
+  id: cross-rs4s
+  kind: site
+  name: Cross RS4S/RS4T/RS5
+  product_url: https://www.cross-traffic.com/en/traffic-light-controllers/
+
 local_supervisor:
   ips: all
   max_sites: 1

--- a/config/gem_supervisor.yaml
+++ b/config/gem_supervisor.yaml
@@ -1,5 +1,11 @@
 # Config for testing a supervisor running on localhost (e.g. one from the rsmp gem)
 # The settings are used for starting a local site connecting to the supervisor tested
+compliance:
+  id: gem-supervisor
+  kind: supervisor
+  name: RSMP Nordic CLI supervisor
+  product_url: https://github.com/rsmp-nordic/rsmp
+
 local_site:
   type: tlc
   site_id: RN+SI0001

--- a/config/gem_tlc.yaml
+++ b/config/gem_tlc.yaml
@@ -1,6 +1,12 @@
 # Config for testing RSMP Nordic traffic light controller emulator.
 # The settings are used for starting a local supervisor listening for the site tested
 # See https://rsmp-nordic.github.io/rsmp_validator/config/
+compliance:
+  id: gem-tlc
+  kind: site
+  name: RSMP Nordic CLI TLC
+  product_url: https://github.com/rsmp-nordic/rsmp
+
 local_supervisor:
   port: 13111
   ips: all

--- a/config/kapsch_etx.yaml
+++ b/config/kapsch_etx.yaml
@@ -1,6 +1,12 @@
 # Config for testing Kapsch ETX traffic light controller.
 # The settings are used for starting a local supervisor listening for the site tested
 # See https://rsmp-nordic.github.io/rsmp_validator/config/
+compliance:
+  id: kapsch-etx
+  kind: site
+  name: Kapsch EcoTrafiX
+  product_url: https://www.kapsch.net/_Resources/Persistent/f9e0a0525985dc4a9d0b3cb6b67476c0b1257b1c/Kapsch_EcoTrafiX-Controller-16_Datasheet-EN.pdf
+
 local_supervisor:
   ips: all
   max_sites: 1

--- a/config/lightmotion_satellite.yaml
+++ b/config/lightmotion_satellite.yaml
@@ -1,6 +1,12 @@
 # Configuration for testing Lightmotion Satellite RSMP proxy software
 # The settings are used for starting a local supervisor listening for the site tested
 # See https://rsmp-nordic.github.io/rsmp_validator/config/
+compliance:
+  id: lightmotion-satellite
+  kind: site
+  name: Lightmotion Satellite
+  product_url: https://lightmotion.fi/
+
 local_supervisor:
   ips: all
   max_sites: 1

--- a/config/semaforica_cartesio.yaml
+++ b/config/semaforica_cartesio.yaml
@@ -1,6 +1,12 @@
 # Config for testing Cross RS4S traffic light controller.
 # The settings are used for starting a local supervisor listening for the site tested
 # See https://rsmp-nordic.github.io/rsmp_validator/config/
+compliance:
+  id: semaforica-cartesio
+  kind: site
+  name: La Semaforica TECSEN Cartesio
+  product_url: https://lasemaforica.com/en/products/cartesio-highest-processing-power-interactive-traffic-controllers/
+
 local_supervisor:
   ips: all
   max_sites: 1

--- a/config/swarco_itc3.yaml
+++ b/config/swarco_itc3.yaml
@@ -1,6 +1,12 @@
 # Config for testing Swarco ITC-3 traffic light controller.
 # The settings are used for starting a local supervisor listening for the site tested
 # See https://rsmp-nordic.github.io/rsmp_validator/config/
+compliance:
+  id: swarco-itc3
+  kind: site
+  name: Swarco ITC-3
+  product_url: https://www.swarco.com/products/traffic-light-controllers/itc-3-traffic-controller
+
 local_supervisor:
   ips: all
   max_sites: 1

--- a/config/tecsen_tmacs_supervisor.yaml
+++ b/config/tecsen_tmacs_supervisor.yaml
@@ -1,5 +1,11 @@
 # The settings are used for starting a local tlc emulator connecting to the supervisor system to be tested
 
+compliance:
+  id: tecsen-tmacs
+  kind: supervisor
+  name: TECSEN TMacs
+  product_url: https://www.tmacs.it/en/
+
 local_site:
   type: tlc
   site_id: CAR_TC_001

--- a/exe/compliance-collector
+++ b/exe/compliance-collector
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require_relative '../lib/rsmp/validator/compliance/collector'
+
+options = {
+  repo: ENV.fetch('COMPLIANCE_SOURCE_REPO', 'rsmp-nordic/rsmp_validator'),
+  website_dir: 'rsmp_website',
+  data_dir: 'rsmp_website_compliance_data',
+  lookback_days: RSMP::Validator::Compliance::Collector::DEFAULT_LOOKBACK_DAYS,
+  overlap_days: RSMP::Validator::Compliance::Collector::DEFAULT_OVERLAP_DAYS,
+  full: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = 'Usage: compliance-collector [options]'
+
+  parser.on('--repo REPO', 'GitHub repository to read workflow artifacts from') do |repo|
+    options[:repo] = repo
+  end
+
+  parser.on('--website-dir PATH', 'Checked out website main branch directory') do |path|
+    options[:website_dir] = path
+  end
+
+  parser.on('--data-dir PATH', 'Checked out website compliance-data branch directory') do |path|
+    options[:data_dir] = path
+  end
+
+  parser.on('--lookback-days DAYS', Integer, 'How many days of runs to inspect in full mode') do |days|
+    options[:lookback_days] = days
+  end
+
+  parser.on('--overlap-days DAYS', Integer, 'How many previous days to reprocess in incremental mode') do |days|
+    options[:overlap_days] = days
+  end
+
+  parser.on('--full', 'Ignore existing compliance-data summary and rebuild from the lookback window') do
+    options[:full] = true
+  end
+end.parse!
+
+token = ENV['GH_TOKEN'] || ENV.fetch('GITHUB_TOKEN', nil)
+abort 'GH_TOKEN or GITHUB_TOKEN is required' unless token && token != ''
+
+github = RSMP::Validator::Compliance::GitHubClient.new(repo: options[:repo], token: token)
+
+RSMP::Validator::Compliance::Collector.new(
+  github: github,
+  website_dir: options[:website_dir],
+  data_dir: options[:data_dir],
+  source_repo: options[:repo],
+  lookback_days: options[:lookback_days],
+  overlap_days: options[:overlap_days],
+  full: options[:full]
+).collect

--- a/exe/rsmp-validator
+++ b/exe/rsmp-validator
@@ -2,6 +2,7 @@
 
 require 'sus'
 require 'sus/config'
+require_relative '../lib/rsmp/validator/compliance/report'
 
 def print_help
   puts <<~HELP
@@ -17,10 +18,11 @@ def print_help
       rsmp-validator test/supervisor/connect_spec.rb
 
     Options:
-      --verbose      Show detailed sus output.
-      --log          Print RSMP log output to stdout.
-      --log PATH     Write RSMP log output to PATH.
-      -h, --help     Show this help.
+      --verbose           Show detailed sus output.
+      --log               Print RSMP log output to stdout.
+      --log PATH          Write RSMP log output to PATH.
+      --report-json PATH  Write a machine-readable compliance report to PATH.
+      -h, --help          Show this help.
 
     Environment:
       SITE_CONFIG        Path to site test configuration.
@@ -32,6 +34,15 @@ end
 if ARGV.first == 'help' || ARGV.include?('--help') || ARGV.include?('-h')
   print_help
   exit 0
+end
+
+# Parse --report-json <path> before Sus::Config.load consumes remaining args.
+report_json_index = ARGV.index('--report-json')
+report_json_path = nil
+if report_json_index
+  ARGV.delete_at(report_json_index)
+  report_json_path = ARGV.delete_at(report_json_index)
+  abort '--report-json requires a path' unless report_json_path
 end
 
 # Parse --log [path] from ARGV before Sus::Config.load consumes remaining args.
@@ -96,11 +107,22 @@ config.log_path = log_path
 
 registry = config.registry
 
-def run_suite(config, registry, output, verbose)
+def run_suite(config, registry, output, verbose, report_options)
   assertions = Sus::Assertions.default(output: output, verbose: verbose)
   config.before_tests(assertions)
   registry.call(assertions)
   config.after_tests(assertions)
+  report_json_path = report_options[:report_json_path]
+  if report_json_path
+    RSMP::Validator::Compliance::Report.write(
+      report_json_path,
+      assertions: assertions,
+      env: ENV,
+      args: ARGV,
+      log_path: log_path,
+      report_json_path: report_json_path
+    )
+  end
   exit(1) unless assertions.passed?
 end
 
@@ -112,9 +134,9 @@ if log_path && config.verbose?
     config.log_path = nil
     config.log_file_io = log_file
     output = Sus::Output.default(TeeIO.new($stderr, log_file))
-    run_suite(config, registry, output, true)
+    run_suite(config, registry, output, true, report_json_path: report_json_path, log_path: log_path)
   end
 else
   output = config.verbose? ? config.output : Sus::Output::Null.new
-  run_suite(config, registry, output, config.verbose?)
+  run_suite(config, registry, output, config.verbose?, report_json_path: report_json_path, log_path: log_path)
 end

--- a/lib/rsmp/validator/compliance/collector.rb
+++ b/lib/rsmp/validator/compliance/collector.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'time'
+require_relative 'compliance_data_store'
+require_relative 'github_client'
+require_relative 'run_builder'
+require_relative 'summary'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Coordinates collecting GitHub artifacts and writing static compliance data.
+      class Collector
+        DEFAULT_LOOKBACK_DAYS = 45
+        DEFAULT_OVERLAP_DAYS = 3
+        SECONDS_PER_DAY = 24 * 60 * 60
+
+        def initialize(github:, website_dir:, data_dir:, source_repo:, **options)
+          @github = github
+          @website_dir = website_dir
+          @source_repo = source_repo
+          @now = options.key?(:now) ? options[:now] : Time.now.utc
+          @lookback_days = options.fetch(:lookback_days, DEFAULT_LOOKBACK_DAYS)
+          @overlap_days = options.fetch(:overlap_days, DEFAULT_OVERLAP_DAYS)
+          @full = options.fetch(:full, false)
+          @store = ComplianceDataStore.new(data_dir)
+        end
+
+        def collect
+          previous_summary = @full ? empty_summary : @store.read_summary
+          reports = @github.reports_since(since: since_for(previous_summary))
+          targets = targets_from_reports(reports)
+          runs = runs_by_target(targets, reports)
+          summary = Summary.new(
+            targets: targets,
+            runs_by_target: runs,
+            previous_summary: previous_summary,
+            now: @now
+          ).to_h
+          write_data(summary, runs)
+          summary
+        end
+
+        private
+
+        def runs_by_target(targets, reports)
+          targets.to_h do |target|
+            target_reports = reports.select { |report| report.dig('target', 'id') == target.fetch('id') }
+            [target.fetch('id'), RunBuilder.new(target, target_reports).runs]
+          end
+        end
+
+        def targets_from_reports(reports)
+          reports.group_by { |report| report.dig('target', 'id') }.filter_map do |_id, target_reports|
+            target_from_reports(target_reports)
+          end
+        end
+
+        def target_from_reports(reports)
+          report = reports.find { |candidate| candidate.dig('target', 'id') }
+          return nil unless report
+
+          target = report.fetch('target').compact
+          workflow_file = report.dig('workflow', 'file')
+          target.merge(
+            'workflow_file' => workflow_file,
+            'workflow_name' => report.dig('workflow', 'name'),
+            'details_url' => details_url(workflow_file)
+          ).compact
+        end
+
+        def details_url(workflow_file)
+          return nil unless workflow_file
+
+          "https://github.com/#{@source_repo}/actions/workflows/#{workflow_file}?query=branch%3Amain+event%3Aschedule"
+        end
+
+        def since_for(previous_summary)
+          latest = latest_completed_at(previous_summary)
+          return lookback_start unless latest && !@full
+
+          latest - (@overlap_days * SECONDS_PER_DAY)
+        end
+
+        def latest_completed_at(summary)
+          Array(summary['targets']).filter_map do |target|
+            parse_time(target.dig('latest_run', 'completed_at'))
+          end.max
+        end
+
+        def lookback_start
+          @now - (@lookback_days * SECONDS_PER_DAY)
+        end
+
+        def write_data(summary, runs)
+          @store.write_summary(summary)
+          runs.each { |target_id, target_runs| target_runs.each { |run| @store.write_run(target_id, run) } }
+          write_website_summary(summary)
+        end
+
+        def write_website_summary(summary)
+          data_dir = File.join(@website_dir, '_data', 'compliance')
+          FileUtils.mkdir_p(data_dir)
+          File.write(File.join(data_dir, 'summary.json'), "#{JSON.pretty_generate(summary)}\n")
+        end
+
+        def empty_summary
+          { 'generated_at' => nil, 'targets' => [] }
+        end
+
+        def parse_time(value)
+          return nil unless value
+
+          Time.parse(value).utc
+        rescue ArgumentError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/compliance_data_store.rb
+++ b/lib/rsmp/validator/compliance/compliance_data_store.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Reads and writes the generated compliance data branch contents.
+      class ComplianceDataStore
+        def initialize(data_dir)
+          @data_dir = data_dir
+        end
+
+        def read_summary
+          return empty_summary unless File.exist?(summary_path)
+
+          JSON.parse(File.read(summary_path))
+        rescue JSON::ParserError
+          empty_summary
+        end
+
+        def write_summary(summary)
+          ensure_dirs
+          File.write(summary_path, pretty_json(summary))
+        end
+
+        def write_run(target_id, run)
+          FileUtils.mkdir_p(run_target_dir(target_id))
+          File.write(run_path(target_id, run), pretty_json(run))
+        end
+
+        private
+
+        def empty_summary
+          { 'generated_at' => nil, 'targets' => [] }
+        end
+
+        def pretty_json(data)
+          "#{JSON.pretty_generate(data)}\n"
+        end
+
+        def ensure_dirs
+          FileUtils.mkdir_p(File.join(@data_dir, 'runs'))
+        end
+
+        def summary_path
+          File.join(@data_dir, 'summary.json')
+        end
+
+        def run_target_dir(target_id)
+          File.join(@data_dir, 'runs', target_id.to_s)
+        end
+
+        def run_path(target_id, run)
+          File.join(run_target_dir(target_id), "#{run.fetch('run_id')}-#{run.fetch('run_attempt')}.json")
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/config_metadata.rb
+++ b/lib/rsmp/validator/compliance/config_metadata.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Reads stable compliance target metadata from a validator YAML config file.
+      class ConfigMetadata
+        def initialize(path)
+          @path = path
+        end
+
+        def target
+          return {} unless @path && File.exist?(@path)
+
+          metadata = YAML.safe_load_file(@path, aliases: true)['compliance']
+          metadata.is_a?(Hash) ? stringify(metadata) : {}
+        rescue Psych::Exception
+          {}
+        end
+
+        private
+
+        def stringify(hash)
+          hash.transform_keys(&:to_s).transform_values { |value| value.is_a?(Hash) ? stringify(value) : value }
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/config_sxl_version.rb
+++ b/lib/rsmp/validator/compliance/config_sxl_version.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Reads the primary SXL version from a validator YAML config file.
+      class ConfigSxlVersion
+        def initialize(path)
+          @path = path
+        end
+
+        def version
+          return nil unless @path && File.exist?(@path)
+
+          extract_version(YAML.safe_load_file(@path, aliases: true)['sxls'])
+        rescue Psych::Exception
+          nil
+        end
+
+        private
+
+        def extract_version(sxls)
+          return sxls.values.first.to_s if sxls.is_a?(Hash)
+
+          extract_array_version(sxls) if sxls.is_a?(Array)
+        end
+
+        def extract_array_version(sxls)
+          first = sxls.first
+          first.is_a?(Hash) ? first['version'].to_s : first.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/github_client.rb
+++ b/lib/rsmp/validator/compliance/github_client.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'open3'
+require 'tmpdir'
+require 'time'
+require 'uri'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Reads completed workflow runs and compliance artifacts from GitHub Actions.
+      class GitHubClient
+        def initialize(repo:, token:, events: %w[schedule])
+          @repo = repo
+          @token = token
+          @events = events
+        end
+
+        def reports_since(since:)
+          workflows.flat_map { |workflow| reports_for_workflow(workflow, since: since) }
+        end
+
+        private
+
+        def workflows
+          response = get_json("/repos/#{@repo}/actions/workflows", 'per_page' => '100')
+          Array(response['workflows']).select { |workflow| workflow['state'] == 'active' }
+        end
+
+        def reports_for_workflow(workflow, since:)
+          @events.flat_map { |event| workflow_runs(workflow.fetch('id'), event: event, since: since) }
+                 .flat_map { |run| reports_for_run(run.fetch('id'), workflow) }
+        end
+
+        def reports_for_run(run_id, workflow = nil)
+          report_artifacts(run_id).flat_map { |artifact| download_report_artifact(artifact) }
+                                  .map { |report| enrich_workflow_metadata(report, workflow) }
+        end
+
+        def enrich_workflow_metadata(report, workflow)
+          return report unless workflow
+
+          report['workflow'] ||= {}
+          report['workflow']['name'] ||= workflow['name']
+          report['workflow']['file'] ||= File.basename(workflow['path'].to_s)
+          report
+        end
+
+        def report_artifacts(run_id)
+          run_artifacts(run_id).select { |artifact| report_artifact?(artifact) }
+        end
+
+        def report_artifact?(artifact)
+          artifact['name'].start_with?('compliance-result-', 'compliance-')
+        end
+
+        def workflow_runs(workflow, event:, since:)
+          response = get_json(workflow_runs_path(workflow), workflow_run_params(event))
+          Array(response['workflow_runs']).select { |run| parse_time(run.fetch('created_at')) >= since }
+        end
+
+        def workflow_runs_path(workflow)
+          "/repos/#{@repo}/actions/workflows/#{workflow}/runs"
+        end
+
+        def workflow_run_params(event)
+          { 'branch' => 'main', 'event' => event, 'status' => 'completed', 'per_page' => '100' }
+        end
+
+        def run_artifacts(run_id)
+          response = get_json("/repos/#{@repo}/actions/runs/#{run_id}/artifacts", 'per_page' => '100')
+          Array(response['artifacts']).reject { |artifact| artifact['expired'] }
+        end
+
+        def download_report_artifact(artifact)
+          Dir.mktmpdir('compliance-artifact') do |dir|
+            download_zip(artifact.fetch('id'), File.join(dir, 'artifact.zip'))
+            unzip_reports(dir)
+          end
+        end
+
+        def download_zip(artifact_id, zip_path)
+          path = "/repos/#{@repo}/actions/artifacts/#{artifact_id}/zip"
+          run_gh_api(path, '--output', zip_path)
+        end
+
+        def unzip_reports(dir)
+          zip_path = File.join(dir, 'artifact.zip')
+          system('unzip', '-q', '-o', zip_path, '-d', dir) || raise("Could not unzip #{zip_path}")
+          Dir[File.join(dir, '*.json')].map { |path| JSON.parse(File.read(path)) }
+        end
+
+        def get_json(path, params = {})
+          response = perform_get(api_uri(path, params))
+          raise_for_response(response)
+          JSON.parse(response.body)
+        end
+
+        def api_uri(path, params)
+          URI("https://api.github.com#{path}").tap do |uri|
+            uri.query = URI.encode_www_form(params) unless params.empty?
+          end
+        end
+
+        def perform_get(uri)
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+            http.request(request(uri))
+          end
+        end
+
+        def request(uri)
+          Net::HTTP::Get.new(uri).tap do |request|
+            request['Accept'] = 'application/vnd.github+json'
+            request['Authorization'] = "Bearer #{@token}" if @token && @token != ''
+            request['X-GitHub-Api-Version'] = '2022-11-28'
+          end
+        end
+
+        def raise_for_response(response)
+          return if response.is_a?(Net::HTTPSuccess)
+
+          raise "GitHub API failed: #{response.code} #{response.body}"
+        end
+
+        def run_gh_api(*args)
+          output, status = Open3.capture2e({ 'GH_TOKEN' => @token }, 'gh', 'api', *args)
+          raise "gh api failed: #{output}" unless status.success?
+        end
+
+        def parse_time(value)
+          Time.parse(value).utc
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/report.rb
+++ b/lib/rsmp/validator/compliance/report.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'time'
+require_relative 'report_failure'
+require_relative 'report_metadata'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Builds the machine-readable compliance report emitted by rsmp-validator.
+      class Report
+        DEFAULT_SCHEMA_VERSION = 1
+
+        def initialize(assertions:, env: ENV, args: ARGV, generated_at: Time.now.utc, **options)
+          @assertions = assertions
+          @args = args
+          @generated_at = generated_at
+          @metadata = ReportMetadata.new(
+            env: env,
+            log_path: options[:log_path],
+            report_json_path: options[:report_json_path]
+          )
+        end
+
+        def self.write(path, **options)
+          report = new(**options).to_h
+          FileUtils.mkdir_p(File.dirname(path))
+          File.write(path, "#{JSON.pretty_generate(report)}\n")
+          report
+        end
+
+        def to_h
+          {
+            'schema_version' => DEFAULT_SCHEMA_VERSION,
+            'generated_at' => @generated_at.iso8601,
+            'target' => @metadata.target,
+            'workflow' => @metadata.workflow,
+            'run' => @metadata.run,
+            'matrix' => @metadata.matrix,
+            'summary' => summary,
+            'failures' => failures
+          }
+        end
+
+        private
+
+        def summary
+          {
+            'status' => @assertions.passed? ? 'passed' : 'failed',
+            'passed' => @assertions.passed?,
+            'test_count' => @assertions.total,
+            'passed_count' => @assertions.passed.size,
+            'failed_count' => @assertions.failed.size,
+            'errored_count' => @assertions.errored.size,
+            'skipped_count' => @assertions.skipped.size,
+            'assertion_count' => @assertions.count
+          }
+        end
+
+        def failures
+          @assertions.each_failure.map { |failure| ReportFailure.new(failure).to_h }
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/report_failure.rb
+++ b/lib/rsmp/validator/compliance/report_failure.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module RSMP
+  module Validator
+    module Compliance
+      # Converts a failed Sus assertion/error into compact JSON-friendly data.
+      class ReportFailure
+        ANSI_ESCAPE = /\e\[[0-9;]*m/
+
+        def initialize(failure)
+          @failure = failure
+        end
+
+        def to_h
+          message = failure_message
+          {
+            'id' => failure_id,
+            'message' => clean_text(message[:text]),
+            'location' => message[:location],
+            'type' => @failure.class.name
+          }.compact
+        end
+
+        private
+
+        def failure_message
+          @failure.message
+        rescue StandardError => e
+          { text: e.message, location: failure_id }
+        end
+
+        def failure_id
+          identity = @failure.respond_to?(:identity) ? @failure.identity : nil
+          identity&.to_s
+        end
+
+        def clean_text(text)
+          return nil unless text
+
+          text.to_s.gsub(ANSI_ESCAPE, '').strip
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/report_metadata.rb
+++ b/lib/rsmp/validator/compliance/report_metadata.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative 'config_metadata'
+require_relative 'config_sxl_version'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Builds static and runtime metadata for a compliance report.
+      class ReportMetadata
+        def initialize(env:, log_path: nil, report_json_path: nil)
+          @env = env
+          @log_path = log_path
+          @report_json_path = report_json_path
+        end
+
+        def target
+          ConfigMetadata.new(config_path).target.merge(env_target_metadata)
+        end
+
+        def workflow
+          env_hash(
+            'name' => 'GITHUB_WORKFLOW',
+            'file' => 'COMPLIANCE_WORKFLOW_FILE',
+            'event' => 'GITHUB_EVENT_NAME',
+            'ref' => 'GITHUB_REF',
+            'sha' => 'GITHUB_SHA'
+          ).merge(workflow_file_from_ref)
+        end
+
+        def run
+          {
+            'id' => integer_env('GITHUB_RUN_ID'),
+            'number' => integer_env('GITHUB_RUN_NUMBER'),
+            'attempt' => integer_env('GITHUB_RUN_ATTEMPT'),
+            'url' => run_url,
+            'log_artifact' => env_value('COMPLIANCE_LOG_ARTIFACT') || @log_path,
+            'report_artifact' => env_value('COMPLIANCE_REPORT_ARTIFACT') || @report_json_path
+          }.compact
+        end
+
+        def matrix
+          {
+            'core' => env_value('CORE_VERSION'),
+            'sxl' => sxl_version,
+            'os' => env_value('RUNNER_OS')
+          }.compact
+        end
+
+        private
+
+        def env_target_metadata
+          env_hash(
+            'id' => 'COMPLIANCE_TARGET_ID',
+            'kind' => 'COMPLIANCE_TARGET_KIND',
+            'name' => 'COMPLIANCE_TARGET_NAME',
+            'product_url' => 'COMPLIANCE_PRODUCT_URL'
+          )
+        end
+
+        def workflow_file_from_ref
+          workflow_ref = env_value('GITHUB_WORKFLOW_REF')
+          match = workflow_ref&.match(%r{/(\.github/workflows/[^@]+)@})
+          match ? { 'file' => File.basename(match[1]) } : {}
+        end
+
+        def env_hash(mapping)
+          mapping.transform_values { |name| env_value(name) }.compact
+        end
+
+        def sxl_version
+          env_value('SXL_VERSION') || ConfigSxlVersion.new(config_path).version
+        end
+
+        def config_path
+          env_value('SITE_CONFIG') || env_value('SUPERVISOR_CONFIG')
+        end
+
+        def integer_env(name)
+          value = env_value(name)
+          value&.to_i
+        end
+
+        def env_value(name)
+          value = @env[name]
+          value unless value.nil? || value == ''
+        end
+
+        def run_url
+          repository = env_value('GITHUB_REPOSITORY')
+          run_id = env_value('GITHUB_RUN_ID')
+          return nil unless repository && run_id
+
+          "https://github.com/#{repository}/actions/runs/#{run_id}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/run_builder.rb
+++ b/lib/rsmp/validator/compliance/run_builder.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'time'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Builds normalized matrix-run records from individual result artifacts.
+      class RunBuilder
+        def initialize(target, reports)
+          @target = target
+          @reports = reports
+        end
+
+        def runs
+          grouped_reports.map { |run_key, cells| build_run(run_key, cells) }
+                         .sort_by { |run| [run['completed_at'] || '', run['run_attempt'].to_i] }
+                         .reverse
+        end
+
+        private
+
+        def grouped_reports
+          @reports.group_by { |report| [report.dig('run', 'id'), report.dig('run', 'attempt')] }
+        end
+
+        def build_run(run_key, cells)
+          normalized_cells = normalized_cells(cells)
+          {
+            'target_id' => @target.fetch('id'),
+            'run_id' => run_key.first,
+            'run_attempt' => run_key.last,
+            'run_url' => first_value(cells, 'run', 'url'),
+            'event' => first_value(cells, 'workflow', 'event'),
+            'completed_at' => completed_at(cells),
+            'status' => run_status(normalized_cells),
+            'passed_cells' => normalized_cells.count { |cell| cell['status'] == 'passed' },
+            'total_cells' => normalized_cells.size,
+            'cells' => normalized_cells
+          }
+        end
+
+        def normalized_cells(cells)
+          return expected_cells.map { |expected| normalized_expected_cell(cells, expected) } if expected_cells.any?
+
+          cells.map { |report| cell_summary(report) }.sort_by { |cell| [cell['core'].to_s, cell['sxl'].to_s] }
+        end
+
+        def expected_cells
+          Array(@target['expected_cells'])
+        end
+
+        def normalized_expected_cell(cells, expected_cell)
+          report = cells.find { |cell| cell_matches?(cell, expected_cell) }
+          report ? cell_summary(report) : expected_cell.merge('status' => 'missing')
+        end
+
+        def cell_matches?(report, expected_cell)
+          expected_cell.all? { |key, value| report.dig('matrix', key) == value }
+        end
+
+        def cell_summary(report)
+          {
+            'core' => report.dig('matrix', 'core'),
+            'sxl' => report.dig('matrix', 'sxl'),
+            'status' => report.dig('summary', 'status') || 'failed',
+            'test_count' => report.dig('summary', 'test_count'),
+            'failed_count' => report.dig('summary', 'failed_count'),
+            'errored_count' => report.dig('summary', 'errored_count'),
+            'log_artifact' => report.dig('run', 'log_artifact'),
+            'report_artifact' => report.dig('run', 'report_artifact'),
+            'failures' => Array(report['failures']).first(10)
+          }.compact
+        end
+
+        def completed_at(cells)
+          cells.map { |cell| parse_time(cell['generated_at']) }.compact.max&.iso8601
+        end
+
+        def first_value(cells, *path)
+          cells.find { |cell| cell.dig(*path) }&.dig(*path)
+        end
+
+        def run_status(cells)
+          cells.all? { |cell| cell['status'] == 'passed' } ? 'passed' : 'failed'
+        end
+
+        def parse_time(value)
+          return nil unless value
+
+          Time.parse(value).utc
+        rescue ArgumentError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/summary.rb
+++ b/lib/rsmp/validator/compliance/summary.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'time'
+require_relative 'run_builder'
+require_relative 'target_summary'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Computes and merges website-ready compliance summaries.
+      class Summary
+        def initialize(targets: [], reports: nil, runs_by_target: nil, previous_summary: nil, now: Time.now.utc)
+          @targets = targets
+          @reports = reports || []
+          @runs_by_target = runs_by_target
+          @previous_summary = previous_summary || { 'targets' => [] }
+          @now = now
+        end
+
+        def to_h
+          { 'generated_at' => @now.iso8601, 'targets' => summarized_targets }
+        end
+
+        private
+
+        def summarized_targets
+          runs = runs_by_target
+          all_targets.map { |target| summarize_target(target, runs[target.fetch('id')] || []) }
+                     .sort_by { |target| [target['kind'].to_s, target['name'].to_s] }
+        end
+
+        def summarize_target(target, runs)
+          TargetSummary.new(
+            target: target,
+            previous: previous_target(target.fetch('id')) || {},
+            runs: runs,
+            now: @now
+          ).to_h
+        end
+
+        def runs_by_target
+          @runs_by_target || build_runs_by_target
+        end
+
+        def build_runs_by_target
+          @targets.to_h do |target|
+            [target.fetch('id'), RunBuilder.new(target, reports_for(target)).runs]
+          end
+        end
+
+        def reports_for(target)
+          @reports.select { |report| report.dig('target', 'id') == target.fetch('id') }
+        end
+
+        def all_targets
+          merged = previous_targets.to_h { |target| [target.fetch('id'), public_target_fields(target)] }
+          @targets.each { |target| merge_target(merged, target) }
+          merged.values
+        end
+
+        def merge_target(merged, target)
+          target_id = target.fetch('id')
+          merged[target_id] = merged.fetch(target_id, {}).merge(public_target_fields(target))
+        end
+
+        def previous_targets
+          Array(@previous_summary['targets'])
+        end
+
+        def previous_target(target_id)
+          previous_targets.find { |target| target['id'] == target_id }
+        end
+
+        def public_target_fields(target)
+          target.except('expected_cells')
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/target_summary.rb
+++ b/lib/rsmp/validator/compliance/target_summary.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'time'
+require_relative 'target_versions'
+
+module RSMP
+  module Validator
+    module Compliance
+      # Merges previous target state with newly observed runs.
+      class TargetSummary
+        SECONDS_PER_DAY = 24 * 60 * 60
+
+        def initialize(target:, previous:, runs:, now: Time.now.utc)
+          @target = target
+          @previous = previous
+          @runs = runs
+          @now = now
+        end
+
+        def to_h
+          @target.merge(
+            'latest_run' => latest_run,
+            'latest_passing_run' => latest_passing_run,
+            'best_run' => best_run,
+            'last_30_days' => last_month_stats,
+            'passed_versions' => passed_versions,
+            'versions' => versions,
+            'recent_runs' => recent_runs
+          )
+        end
+
+        private
+
+        def latest_run
+          latest_record([@previous['latest_run'], *@runs])
+        end
+
+        def latest_passing_run
+          latest_record([@previous['latest_passing_run'], *new_passing_runs])
+        end
+
+        def new_passing_runs
+          @runs.select { |run| run['status'] == 'passed' }
+        end
+
+        def best_run
+          latest_passing_run || best_partial_run([@previous['best_run'], *@runs].compact)
+        end
+
+        def recent_runs
+          @recent_runs ||= sort_runs(recent_run_values.select { |run| within_last_month?(run['completed_at']) })
+        end
+
+        def recent_run_values
+          merged = Array(@previous['recent_runs']).to_h { |run| [run_key(run), run] }
+          @runs.each { |run| merged[run_key(run)] = compact_run(run) }
+          merged.values
+        end
+
+        def compact_run(run)
+          run.slice('target_id', 'run_id', 'run_attempt', 'run_url', 'event', 'completed_at', 'status', 'passed_cells',
+                    'total_cells')
+        end
+
+        def versions
+          @versions ||= TargetVersions.new(previous: @previous['versions'], runs: @runs).to_a
+        end
+
+        def passed_versions
+          versions.select { |version| version['latest_passing_run'] }.map { |version| version.slice('core', 'sxl') }
+        end
+
+        def last_month_stats
+          total = recent_runs.sum { |run| run['total_cells'].to_i }
+          passed = recent_runs.sum { |run| run['passed_cells'].to_i }
+          { 'passed_cells' => passed, 'total_cells' => total, 'pass_percentage' => pass_percentage(passed, total) }
+        end
+
+        def pass_percentage(passed, total)
+          return nil unless total.positive?
+
+          ((passed.to_f / total) * 100).round(1)
+        end
+
+        def latest_record(records)
+          records.compact.max_by { |record| [record['completed_at'] || '', record['run_attempt'].to_i] }
+        end
+
+        def best_partial_run(runs)
+          runs.max_by { |run| [pass_ratio(run), run['completed_at'] || ''] }
+        end
+
+        def pass_ratio(run)
+          total = run['total_cells'].to_i
+          total.positive? ? run['passed_cells'].to_f / total : 0.0
+        end
+
+        def sort_runs(runs)
+          runs.sort_by { |run| [run['completed_at'] || '', run['run_attempt'].to_i] }.reverse
+        end
+
+        def within_last_month?(time)
+          parsed = parse_time(time)
+          parsed && parsed >= @now - (30 * SECONDS_PER_DAY)
+        end
+
+        def run_key(run)
+          [run['run_id'], run['run_attempt']]
+        end
+
+        def parse_time(value)
+          return nil unless value
+
+          Time.parse(value).utc
+        rescue ArgumentError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/rsmp/validator/compliance/target_versions.rb
+++ b/lib/rsmp/validator/compliance/target_versions.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module RSMP
+  module Validator
+    module Compliance
+      # Merges accumulated per-version state with newly observed run cells.
+      class TargetVersions
+        def initialize(previous:, runs:)
+          @previous = previous
+          @runs = runs
+        end
+
+        def to_a
+          merged_versions.values.sort_by { |version| [version['core'].to_s, version['sxl'].to_s] }.reverse
+        end
+
+        private
+
+        def merged_versions
+          merged = Array(@previous).to_h { |version| [version_key(version), version] }
+          @runs.each { |run| merge_run_versions(merged, run) }
+          merged
+        end
+
+        def merge_run_versions(merged, run)
+          run.fetch('cells', []).each do |cell|
+            merged[version_key(cell)] = merge_version(merged[version_key(cell)], run, cell)
+          end
+        end
+
+        def merge_version(previous, run, cell)
+          latest = cell_run_summary(run, cell)
+          version_fields(cell).merge(
+            'last_status' => latest['status'],
+            'latest_run' => latest,
+            'latest_passing_run' => latest_passing_run(previous, latest)
+          )
+        end
+
+        def latest_passing_run(previous, latest)
+          latest['status'] == 'passed' ? latest : previous&.fetch('latest_passing_run', nil)
+        end
+
+        def version_fields(cell)
+          cell.slice('core', 'sxl')
+        end
+
+        def cell_run_summary(run, cell)
+          run.slice('run_id', 'run_attempt', 'run_url', 'event', 'completed_at').merge(
+            cell.slice('status', 'test_count', 'failed_count', 'errored_count', 'log_artifact', 'report_artifact')
+          )
+        end
+
+        def version_key(version)
+          [version['core'], version['sxl']]
+        end
+      end
+    end
+  end
+end

--- a/test/validator/compliance_collector_spec.rb
+++ b/test/validator/compliance_collector_spec.rb
@@ -1,0 +1,212 @@
+require 'json'
+require 'tmpdir'
+require_relative '../../lib/rsmp/validator/compliance/collector'
+
+module ComplianceCollectorSpec
+  class FakeGitHub
+    attr_reader :since_values
+
+    def initialize(reports)
+      @reports = reports
+      @since_values = []
+    end
+
+    def reports_since(since:)
+      @since_values << since
+      @reports
+    end
+  end
+
+  module_function
+
+  def target
+    {
+      'id' => 'demo',
+      'kind' => 'site',
+      'name' => 'Demo TLC',
+      'product_url' => 'https://example.test/demo',
+      'workflow_file' => 'demo.yaml',
+      'details_url' => 'https://github.com/rsmp-nordic/rsmp_validator/actions/workflows/demo.yaml?query=branch%3Amain+event%3Aschedule'
+    }
+  end
+
+  def previous_summary
+    {
+      'generated_at' => '2026-06-16T08:00:00Z',
+      'targets' => [
+        target.merge(
+          'latest_run' => run_summary(1, 'failed', '2026-06-10T00:00:00Z', 1),
+          'latest_passing_run' => nil,
+          'best_run' => run_summary(1, 'failed', '2026-06-10T00:00:00Z', 1),
+          'last_30_days' => { 'passed_cells' => 1, 'total_cells' => 2, 'pass_percentage' => 50.0 },
+          'passed_versions' => [{ 'core' => '3.2.2', 'sxl' => '1.2.1' }],
+          'versions' => [version_summary('3.2.2', 'passed', '2026-06-10T00:00:00Z')],
+          'recent_runs' => [run_summary(1, 'failed', '2026-06-10T00:00:00Z', 1)]
+        )
+      ]
+    }
+  end
+
+  def report(run_id, attempt, core, status, generated_at)
+    {
+      'generated_at' => generated_at,
+      'target' => target.slice('id', 'kind', 'name', 'product_url'),
+      'workflow' => { 'name' => 'Demo', 'file' => 'demo.yaml', 'event' => 'schedule' },
+      'run' => { 'id' => run_id, 'attempt' => attempt, 'url' => "https://example.test/#{run_id}" },
+      'matrix' => { 'core' => core, 'sxl' => '1.2.1' },
+      'summary' => { 'status' => status, 'test_count' => 10, 'failed_count' => failed_count(status) }
+    }
+  end
+
+  def run_summary(run_id, status, completed_at, passed_cells)
+    {
+      'target_id' => 'demo',
+      'run_id' => run_id,
+      'run_attempt' => 1,
+      'run_url' => "https://example.test/#{run_id}",
+      'event' => 'schedule',
+      'completed_at' => completed_at,
+      'status' => status,
+      'passed_cells' => passed_cells,
+      'total_cells' => 2
+    }
+  end
+
+  def version_summary(core, status, completed_at)
+    run = {
+      'run_id' => 1,
+      'run_attempt' => 1,
+      'run_url' => 'https://example.test/1',
+      'event' => 'schedule',
+      'completed_at' => completed_at,
+      'status' => status
+    }
+    {
+      'core' => core,
+      'sxl' => '1.2.1',
+      'last_status' => status,
+      'latest_run' => run,
+      'latest_passing_run' => status == 'passed' ? run : nil
+    }
+  end
+
+  def failed_count(status)
+    status == 'passed' ? 0 : 1
+  end
+end
+
+describe RSMP::Validator::Compliance::Summary do
+  it 'merges latest and latest passing runs from previous summary and new runs' do
+    runs = {
+      'demo' => [
+        {
+          'target_id' => 'demo',
+          'run_id' => 2,
+          'run_attempt' => 1,
+          'run_url' => 'https://example.test/2',
+          'event' => 'schedule',
+          'completed_at' => '2026-06-17T00:00:01Z',
+          'status' => 'passed',
+          'passed_cells' => 2,
+          'total_cells' => 2,
+          'cells' => [
+            { 'core' => '3.2.2', 'sxl' => '1.2.1', 'status' => 'passed' },
+            { 'core' => '3.3.0', 'sxl' => '1.2.1', 'status' => 'passed' }
+          ]
+        }
+      ]
+    }
+
+    summary = RSMP::Validator::Compliance::Summary.new(
+      targets: [ComplianceCollectorSpec.target],
+      runs_by_target: runs,
+      previous_summary: ComplianceCollectorSpec.previous_summary,
+      now: Time.utc(2026, 6, 17, 8, 0, 0)
+    ).to_h['targets'].first
+
+    expect(summary['latest_run']['run_id']).to be == 2
+    expect(summary['latest_passing_run']['run_id']).to be == 2
+    expect(summary['passed_versions']).to be == [
+      { 'core' => '3.3.0', 'sxl' => '1.2.1' },
+      { 'core' => '3.2.2', 'sxl' => '1.2.1' }
+    ]
+    expect((summary['last_30_days']['pass_percentage'] - 75.0).abs < 0.01).to be == true
+  end
+
+  it 'keeps an older latest pass when the new run fails' do
+    runs = {
+      'demo' => [
+        ComplianceCollectorSpec.run_summary(2, 'failed', '2026-06-17T00:00:01Z', 1).merge(
+          'cells' => [{ 'core' => '3.2.2', 'sxl' => '1.2.1', 'status' => 'failed' }]
+        )
+      ]
+    }
+
+    summary = RSMP::Validator::Compliance::Summary.new(
+      targets: [ComplianceCollectorSpec.target],
+      runs_by_target: runs,
+      previous_summary: ComplianceCollectorSpec.previous_summary,
+      now: Time.utc(2026, 6, 17, 8, 0, 0)
+    ).to_h['targets'].first
+
+    expect(summary['latest_run']['run_id']).to be == 2
+    expect(summary['latest_passing_run'].nil?).to be == true
+    expect(summary['versions'].first['latest_passing_run']['run_id']).to be == 1
+  end
+end
+
+describe RSMP::Validator::Compliance::Collector do
+  it 'uses the data branch summary as state and writes new run summaries' do
+    Dir.mktmpdir do |website_dir|
+      Dir.mktmpdir do |data_dir|
+        File.write(File.join(data_dir, 'summary.json'),
+                   "#{JSON.pretty_generate(ComplianceCollectorSpec.previous_summary)}\n")
+        github = ComplianceCollectorSpec::FakeGitHub.new([
+                                                           ComplianceCollectorSpec.report(2, 1, '3.2.2', 'passed',
+                                                                                          '2026-06-17T00:00:00Z'),
+                                                           ComplianceCollectorSpec.report(2, 1, '3.3.0', 'passed',
+                                                                                          '2026-06-17T00:00:01Z')
+                                                         ])
+
+        data = RSMP::Validator::Compliance::Collector.new(
+          github: github,
+          website_dir: website_dir,
+          data_dir: data_dir,
+          source_repo: 'rsmp-nordic/rsmp_validator',
+          now: Time.utc(2026, 6, 17, 8, 0, 0)
+        ).collect
+
+        expect(github.since_values.first).to be == Time.utc(2026, 6, 7, 0, 0, 0)
+        expect(data['targets'].first['latest_run']['run_id']).to be == 2
+        expect(File.exist?(File.join(data_dir, 'runs/demo/2-1.json'))).to be == true
+        expect(File.exist?(File.join(website_dir, '_data/compliance/summary.json'))).to be == true
+      end
+    end
+  end
+
+  it 'ignores previous data branch summary in full mode' do
+    Dir.mktmpdir do |website_dir|
+      Dir.mktmpdir do |data_dir|
+        File.write(File.join(data_dir, 'summary.json'),
+                   "#{JSON.pretty_generate(ComplianceCollectorSpec.previous_summary)}\n")
+        github = ComplianceCollectorSpec::FakeGitHub.new([
+                                                           ComplianceCollectorSpec.report(2, 1, '3.2.2', 'passed',
+                                                                                          '2026-06-17T00:00:00Z')
+                                                         ])
+
+        data = RSMP::Validator::Compliance::Collector.new(
+          github: github,
+          website_dir: website_dir,
+          data_dir: data_dir,
+          source_repo: 'rsmp-nordic/rsmp_validator',
+          now: Time.utc(2026, 6, 17, 8, 0, 0),
+          full: true
+        ).collect
+
+        expect(github.since_values.first).to be == Time.utc(2026, 5, 3, 8, 0, 0)
+        expect(data['targets'].first['latest_run']['run_id']).to be == 2
+        expect(data['targets'].first['versions'].length).to be == 1
+      end
+    end
+  end
+end

--- a/test/validator/compliance_report_spec.rb
+++ b/test/validator/compliance_report_spec.rb
@@ -1,0 +1,78 @@
+require 'json'
+require 'tmpdir'
+require 'sus'
+require_relative '../../lib/rsmp/validator/compliance/report'
+
+describe RSMP::Validator::Compliance::Report do
+  def assertions_with_failure
+    assertions = Sus::Assertions.default(output: Sus::Output::Null.new)
+    assertions.assert(false, 'expected this to fail')
+    assertions
+  end
+
+  def config_path(dir)
+    path = File.join(dir, 'site.yaml')
+    File.write(path, <<~YAML)
+      compliance:
+        id: cross-rs4s
+        kind: site
+        name: Cross RS4S/RS4T/RS5
+        product_url: https://www.cross-traffic.com/en/traffic-light-controllers/
+      sxls:
+        tlc: '1.2.1'
+    YAML
+    path
+  end
+
+  it 'writes config target metadata and failed status' do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'report.json')
+      RSMP::Validator::Compliance::Report.write(
+        path,
+        assertions: assertions_with_failure,
+        env: {
+          'SITE_CONFIG' => config_path(dir),
+          'GITHUB_WORKFLOW' => 'Cross RS4S',
+          'GITHUB_WORKFLOW_REF' => 'rsmp-nordic/rsmp_validator/.github/workflows/cross_rs4s.yaml@refs/heads/main',
+          'GITHUB_EVENT_NAME' => 'schedule',
+          'GITHUB_REPOSITORY' => 'rsmp-nordic/rsmp_validator',
+          'GITHUB_RUN_ID' => '123',
+          'GITHUB_RUN_NUMBER' => '45',
+          'GITHUB_RUN_ATTEMPT' => '2',
+          'CORE_VERSION' => '3.2.2'
+        },
+        log_path: 'validator-cross.log',
+        report_json_path: 'compliance-cross.json',
+        generated_at: Time.utc(2026, 6, 17, 8, 0, 0)
+      )
+
+      report = JSON.parse(File.read(path))
+      expect(report['target']['id']).to be == 'cross-rs4s'
+      expect(report['target']['product_url']).to be == 'https://www.cross-traffic.com/en/traffic-light-controllers/'
+      expect(report['workflow']['file']).to be == 'cross_rs4s.yaml'
+      expect(report['run']['url']).to be == 'https://github.com/rsmp-nordic/rsmp_validator/actions/runs/123'
+      expect(report['run']['log_artifact']).to be == 'validator-cross.log'
+      expect(report['run']['report_artifact']).to be == 'compliance-cross.json'
+      expect(report['matrix']).to be == { 'core' => '3.2.2', 'sxl' => '1.2.1' }
+      expect(report['summary']['status']).to be == 'failed'
+      expect(report['summary']['failed_count']).to be == 1
+      expect(report['failures'].length).to be == 1
+    end
+  end
+
+  it 'loads target metadata and the SXL version from validator config' do
+    assertions = Sus::Assertions.default(output: Sus::Output::Null.new)
+    assertions.assert(true)
+
+    report = RSMP::Validator::Compliance::Report.new(
+      assertions: assertions,
+      env: { 'SITE_CONFIG' => 'config/gem_tlc.yaml', 'CORE_VERSION' => '3.2.2' },
+      generated_at: Time.utc(2026, 6, 17, 8, 0, 0)
+    ).to_h
+
+    expect(report['target']['id']).to be == 'gem-tlc'
+    expect(report['target']['name']).to be == 'RSMP Nordic CLI TLC'
+    expect(report['matrix']['sxl']).to be == '1.2.1'
+    expect(report['summary']['status']).to be == 'passed'
+  end
+end


### PR DESCRIPTION
Static compliance reporting pipeline:

In rsmp_validator:
Test workflows now emit JSON reports with --report-json.
Compliance metadata now lives in each validator config under compliance:.
Added a central compliance-collector workflow, runnable nightly or manually.
Collector reads GitHub Actions artifacts, merges them into accumulated summary state, and writes generated data.
Historical generated data is stored on the website repo’s compliance-data branch.
Website main only receives _data/compliance/summary.json.
Added Ruby classes/tests for report generation, artifact collection, run normalization, summary merging, and data storage.

In rsmp_website:
Compliance page now renders from generated Jekyll data.
Shows latest run, latest passing/best run, last-30-days stats, and passed core/SXL versions.